### PR TITLE
Add_ocp_permissions

### DIFF
--- a/deploy/fake-gpu-operator/templates/device-plugin/ocp/rbac.yml
+++ b/deploy/fake-gpu-operator/templates/device-plugin/ocp/rbac.yml
@@ -26,4 +26,34 @@ roleRef:
   kind: ClusterRole
   name: nvidia-device-plugin
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterlogging-collector-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clusterlogging-collector-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterlogging-collector-metrics
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
 {{ end }}


### PR DESCRIPTION
Fix: 
```User system:serviceaccount:openshift-monitoring:prometheus-k8s cannot list resource pods in API group "" in the namespace gpu-operator```

https://access.redhat.com/solutions/6719831