### PR TITLE
fix RBAC: add patch verb to ConfigMap resource for status-updater and SSA attributes for updating status

### DIFF
--- a/deploy/fake-gpu-operator/templates/status-updater/clusterrole.yaml
+++ b/deploy/fake-gpu-operator/templates/status-updater/clusterrole.yaml
@@ -20,6 +20,7 @@ rules:
     verbs:
       - get
       - update
+      - patch
       - create
       - list
       - delete

--- a/internal/common/topology/kubernetes.go
+++ b/internal/common/topology/kubernetes.go
@@ -50,7 +50,7 @@ func UpdateNodeTopologyCM(kubeclient kubernetes.Interface, nodeTopology *NodeTop
 	}
 
 	_, err = kubeclient.CoreV1().ConfigMaps(
-		viper.GetString(constants.EnvTopologyCmNamespace)).Apply(context.TODO(), cm, metav1.ApplyOptions{})
+		viper.GetString(constants.EnvTopologyCmNamespace)).Apply(context.TODO(), cm, metav1.ApplyOptions{FieldManager: "fake-gpu-operator", Force: true})
 	return err
 }
 


### PR DESCRIPTION
Resolves https://github.com/run-ai/fake-gpu-operator/issues/93 
Add missing permission for status-updater, so that it can patch ConfigMap with the gpu usage information.

It also adds ServiceSideApply configuration for the ConfigMap status update.

Before this change status-updated was failing:

```
2024/10/24 16:43:39 StatusUpdater was Started
2024/10/24 16:43:39 Pruning topology ConfigMaps...
2024/10/24 16:43:39 Starting pod controller
2024/10/24 16:43:39 Starting node controller
2024/10/24 16:43:39 Handling node addition: worker0.fake-gpu.domain
2024/10/24 16:43:39 Handling node addition: worker1.fake-gpu.domain
2024/10/24 16:43:39 Handling node addition: worker2.fake-gpu.domain
2024/10/24 16:43:40 Handling pod addition: gpu-test-5b7dc795b7-pdc2w
2024/10/24 16:43:40 Failed to handle pod addition: PatchOptions.meta.k8s.io "" is invalid: fieldManager: Required value: is required for apply patch
```

After the change it work fine:

```
24/10/24 16:40:05 StatusUpdater was Started
2024/10/24 16:40:05 Starting pod controller
2024/10/24 16:40:05 Pruning topology ConfigMaps...
2024/10/24 16:40:05 Starting node controller
2024/10/24 16:40:05 Handling node addition: worker0.fake-gpu.domain
2024/10/24 16:40:05 Handling node addition: worker2.fake-gpu.domain
2024/10/24 16:40:05 Handling node addition: worker1.fake-gpu.domain
2024/10/24 16:40:06 Handling pod addition: gpu-test-5b7dc795b7-pdc2w
2024/10/24 16:40:06 Requested GPUs: 1
2024/10/24 16:40:06 GPU GPU-63692fb7-614b-5f91-ad15-970ccdd4e01e is free, allocating...
```

with `ConfigMap` `topology-worker0.fake-gpu.domain` updated:

```yaml
gpuMemory: 11441
gpuProduct: Tesla-K80
gpus:
    - id: GPU-63692fb7-614b-5f91-ad15-970ccdd4e01e
      status:
        allocatedBy:
            namespace: gpu-operator
            pod: gpu-test-5b7dc795b7-pdc2w
            container: container1
        podGpuUsageStatus:
            ea2ab33a-2450-41f7-98f7-224ec0f0f313:
                utilization:
                    min: 25
                    max: 25
                fbUsed: 11441
                useKnativeUtilization: false
    - id: GPU-b0db99ec-4e1a-5a2a-bda6-c2e5f66e1877
      status:
        allocatedBy:
            namespace: ""
            pod: ""
            container: ""
        podGpuUsageStatus: {}
migStrategy: mixed
```

and Prometheus metrics endpoint returning

```
# HELP DCGM_FI_DEV_FB_FREE GPU Framebuffer Free
# TYPE DCGM_FI_DEV_FB_FREE gauge
DCGM_FI_DEV_FB_FREE{Hostname="nvidia-dcgm-exporter-90cea9",UUID="GPU-63692fb7-614b-5f91-ad15-970ccdd4e01e",container="container1",device="nvidia0",gpu="0",modelName="Tesla-K80",namespace="gpu-operator",pod="gpu-test-5b7dc795b7-pdc2w"} 0
DCGM_FI_DEV_FB_FREE{Hostname="nvidia-dcgm-exporter-90cea9",UUID="GPU-b0db99ec-4e1a-5a2a-bda6-c2e5f66e1877",container="",device="nvidia1",gpu="1",modelName="Tesla-K80",namespace="",pod=""} 11441
# HELP DCGM_FI_DEV_FB_USED GPU Framebuffer Used
# TYPE DCGM_FI_DEV_FB_USED gauge
DCGM_FI_DEV_FB_USED{Hostname="nvidia-dcgm-exporter-90cea9",UUID="GPU-63692fb7-614b-5f91-ad15-970ccdd4e01e",container="container1",device="nvidia0",gpu="0",modelName="Tesla-K80",namespace="gpu-operator",pod="gpu-test-5b7dc795b7-pdc2w"} 11441
DCGM_FI_DEV_FB_USED{Hostname="nvidia-dcgm-exporter-90cea9",UUID="GPU-b0db99ec-4e1a-5a2a-bda6-c2e5f66e1877",container="",device="nvidia1",gpu="1",modelName="Tesla-K80",namespace="",pod=""} 0
# HELP DCGM_FI_DEV_GPU_UTIL GPU Utilization
# TYPE DCGM_FI_DEV_GPU_UTIL gauge
DCGM_FI_DEV_GPU_UTIL{Hostname="nvidia-dcgm-exporter-90cea9",UUID="GPU-63692fb7-614b-5f91-ad15-970ccdd4e01e",container="container1",device="nvidia0",gpu="0",modelName="Tesla-K80",namespace="gpu-operator",pod="gpu-test-5b7dc795b7-pdc2w"} 25
DCGM_FI_DEV_GPU_UTIL{Hostname="nvidia-dcgm-exporter-90cea9",UUID="GPU-b0db99ec-4e1a-5a2a-bda6-c2e5f66e1877",container="",device="nvidia1",gpu="1",modelName="Tesla-K80",namespace="",pod=""} 0
```