### PR TITLE
feat: support custom runtimeClass and topology namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_DIR=$(shell pwd)/bin
 COMPONENTS?=device-plugin status-updater kwok-gpu-device-plugin status-exporter topology-server mig-faker jupyter-notebook
 
-DOCKER_REPO_BASE=gcr.io/run-ai-lab/fake-gpu-operator
+DOCKER_REPO_BASE?=gcr.io/run-ai-lab/fake-gpu-operator
 DOCKER_TAG?=0.0.0-dev
 NAMESPACE=gpu-operator
 

--- a/cmd/nvidia-smi/main.go
+++ b/cmd/nvidia-smi/main.go
@@ -40,11 +40,14 @@ func main() {
 		fmt.Println("Debug mode enabled")
 	}
 
-	err := os.Setenv(constants.EnvTopologyCmNamespace, "gpu-operator")
-	if err != nil {
-		panic(err)
+	if _, ok := os.LookupEnv(constants.EnvTopologyCmNamespace); !ok {
+		err := os.Setenv(constants.EnvTopologyCmNamespace, "gpu-operator")
+		if err != nil {
+			panic(err)
+		}
 	}
-	err = os.Setenv(constants.EnvTopologyCmName, "topology")
+
+	err := os.Setenv(constants.EnvTopologyCmName, "topology")
 	if err != nil {
 		panic(err)
 	}
@@ -66,7 +69,8 @@ func getNvidiaSmiArgs() (args nvidiaSmiArgs) {
 	}
 
 	// Send http request to topology-server to get the topology
-	topologyUrl := "http://topology-server.gpu-operator/topology/nodes/" + nodeName
+	topologyUrl := fmt.Sprintf("http://topology-server.%s/topology/nodes/%s",
+		os.Getenv(constants.EnvTopologyCmNamespace), nodeName)
 	if conf.Debug {
 		fmt.Printf("Requesting topology from: %s\n", topologyUrl)
 	}

--- a/deploy/fake-gpu-operator/templates/runtime-class.yml
+++ b/deploy/fake-gpu-operator/templates/runtime-class.yml
@@ -1,5 +1,5 @@
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
-  name: nvidia
+  name: {{ .Values.runtimeClass.name | default "fake-nvidia" }}
 handler: runc

--- a/deploy/fake-gpu-operator/values.yaml
+++ b/deploy/fake-gpu-operator/values.yaml
@@ -92,3 +92,6 @@ topology:
       gpuMemory: 11441
   nodePoolLabelKey: run.ai/simulated-gpu-node-pool
   migStrategy: mixed
+
+runtimeClass:
+  name: fake-nvidia


### PR DESCRIPTION
- Allow configuring a custom `runtimeClass.name` to avoid conflict with NVIDIA's default runtime
- Topology server namespace in `nvidia-smi` is now configurable via the `TOPOLOGY_CM_NAMESPACE` environment variable instead of being hardcoded to `gpu-operator`

### Example Helm upgrade command

```bash
helm upgrade --install fake-gpu-operator ~/git/fake-gpu-operator/deploy/fake-gpu-operator \
  --namespace runai --create-namespace \
  --set runtimeClass.name=fake-nvidia
```

### Example: Verified Pod Spec

This Pod verifies that the custom runtimeClass and dynamic topology namespace injection works correctly.

<details> <summary>Click to expand pod.yaml</summary>

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: "1"
spec:
  runtimeClassName: fake-nvidia
  containers:
  - name: ubuntu
    image: ubuntu:22.04
    command: ["/bin/bash", "-c"]
    args:
      - |
        sleep infinity;
    resources:
      limits:
        nvidia.com/gpu: 1
    env:
      - name: NODE_NAME
        valueFrom:
          fieldRef:
            fieldPath: spec.nodeName

```
</details>