### PR TITLE
Revert "upload fake gpu operator helm chart to gcs for airgapped"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,3 @@ jobs:
       - name: Push
         run: |
           helm push ./charts/fake-gpu-operator-${{ needs.set-release-vars.outputs.release_version }}.tgz oci://${{ env.DOCKER_REGISTRY }}
-  sync-chart:
-    needs: [release-helm,set-release-vars,release-docker]
-    uses: run-ai/internal-actions/.github/workflows/sync-fgo-gcs.yaml@master
-    with:
-      chart_name: fake-gpu-operator
-      chart_version: ${{ needs.set-release-vars.outputs.release_version }}
-      gcs_bucket: fake-gpu-operator
-    secrets:
-      GCLOUD_CREDENTIALS_JSON: ${{ secrets.STAGING_GCLOUD_SERVICE_JSON_CONTENT }}
-


### PR DESCRIPTION
Reverts run-ai/fake-gpu-operator#122 since it breaks the CI