### PR TITLE
fix: use distinct app label for kwok dcgm-exporter service

### DIFF
--- a/deploy/fake-gpu-operator/templates/status-exporter/kwok-deployment.yaml
+++ b/deploy/fake-gpu-operator/templates/status-exporter/kwok-deployment.yaml
@@ -4,20 +4,17 @@ kind: Deployment
 metadata:
   name: nvidia-dcgm-exporter-kwok
   labels:
-    app: nvidia-dcgm-exporter
-    component: status-exporter-kwok
+    app: nvidia-dcgm-exporter-kwok
     app.kubernetes.io/name: nvidia-container-toolkit
 spec:
   selector:
     matchLabels:
-      app: nvidia-dcgm-exporter
-      component: status-exporter-kwok
+      app: nvidia-dcgm-exporter-kwok
   replicas: 1
   template:
     metadata:
       labels:
-        app: nvidia-dcgm-exporter
-        component: status-exporter-kwok
+        app: nvidia-dcgm-exporter-kwok
         app.kubernetes.io/name: nvidia-container-toolkit
     spec:
       containers:

--- a/deploy/fake-gpu-operator/templates/status-exporter/kwok-service.yaml
+++ b/deploy/fake-gpu-operator/templates/status-exporter/kwok-service.yaml
@@ -5,8 +5,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
   labels:
-    app: nvidia-dcgm-exporter
-    component: status-exporter-kwok
+    app: nvidia-dcgm-exporter-kwok
   name: nvidia-dcgm-exporter-kwok
 spec:
   ports:
@@ -15,7 +14,6 @@ spec:
       protocol: TCP
       targetPort: 9400
   selector:
-    app: nvidia-dcgm-exporter
-    component: status-exporter-kwok
+    app: nvidia-dcgm-exporter-kwok
   type: ClusterIP
 {{- end -}}


### PR DESCRIPTION
## Summary

- The RunAI reconciler discovers dcgm-exporter by searching for services with `app=nvidia-dcgm-exporter`. Since #170 introduced a second service (`nvidia-dcgm-exporter-kwok`) with the same label, the reconciler fails with "found more than one dcgm-exporter service in the cluster", marking the NVIDIA GPU stack as unavailable.
- Change the kwok service, deployment, and PrometheusRule to use `app=nvidia-dcgm-exporter-kwok` so only one service matches the reconciler's lookup.
- Prometheus scraping is unaffected — it relies on the `prometheus.io/scrape` annotation, not the `app` label.

Fixes: RUN-38125

## Test plan

- [x] Deployed to `sh-kind-fake-c72` env-in-a-click cluster
- [x] Verified `runai-public` ConfigMap shows `nvidia: available: true` and all conditions (`Reconciled`, `DependenciesFulfilled`, `Deployed`, `Available`) are `True`
- [x] Verified Prometheus still scrapes the kwok exporter (`serviceMonitor/runai/nvidia-dcgm-exporter/0` target is active)