### PR TITLE
feat: new API types + backwards compatibility normalization

### DIFF
--- a/deploy/fake-gpu-operator/templates/topology-cm.yml
+++ b/deploy/fake-gpu-operator/templates/topology-cm.yml
@@ -2,7 +2,11 @@
 apiVersion: v1
 data:
   topology.yml: |-
+{{- if .Values.cluster }}
+{{ toYaml .Values.cluster | indent 4 }}
+{{- else }}
 {{ toYaml .Values.topology | indent 4 }}
+{{- end }}
 kind: ConfigMap
 metadata:
   name: topology

--- a/internal/common/topology/kubernetes.go
+++ b/internal/common/topology/kubernetes.go
@@ -76,6 +76,29 @@ func GetClusterTopologyFromCM(kubeclient kubernetes.Interface) (*ClusterTopology
 	return cluster, nil
 }
 
+// GetClusterConfigFromCM reads the cluster topology ConfigMap and returns a
+// ClusterConfig, auto-detecting and normalizing old format if needed.
+func GetClusterConfigFromCM(kubeclient kubernetes.Interface) (*ClusterConfig, error) {
+	topologyCm, err := kubeclient.CoreV1().ConfigMaps(
+		viper.GetString(constants.EnvTopologyCmNamespace)).Get(
+		context.TODO(), viper.GetString(constants.EnvTopologyCmName), metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get topology configmap: %v", err)
+	}
+
+	return FromClusterConfigCM(topologyCm)
+}
+
+// FromClusterConfigCM parses a ConfigMap into a ClusterConfig, handling both
+// old and new formats transparently.
+func FromClusterConfigCM(cm *corev1.ConfigMap) (*ClusterConfig, error) {
+	data, ok := cm.Data[CmTopologyKey]
+	if !ok {
+		return nil, fmt.Errorf("topology configmap missing key %q", CmTopologyKey)
+	}
+	return ParseAndNormalizeTopology([]byte(data))
+}
+
 func FromClusterTopologyCM(cm *corev1.ConfigMap) (*ClusterTopology, error) {
 	var clusterTopology ClusterTopology
 	err := yaml.Unmarshal([]byte(cm.Data[CmTopologyKey]), &clusterTopology)

--- a/internal/common/topology/normalize.go
+++ b/internal/common/topology/normalize.go
@@ -1,5 +1,11 @@
 package topology
 
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
 // normalizeOldToClusterConfig converts the old ClusterTopology format into the
 // new ClusterConfig format. This enables backwards compatibility: users can keep
 // using the old topology: values.yaml format and it gets normalized at read time.
@@ -51,4 +57,69 @@ func normalizeNodePool(old NodePoolTopology) NodePoolConfig {
 	}
 
 	return poolConfig
+}
+
+// ParseAndNormalizeTopology takes raw YAML bytes from the topology ConfigMap and
+// returns a ClusterConfig. It auto-detects whether the data is in old (ClusterTopology)
+// or new (ClusterConfig) format.
+func ParseAndNormalizeTopology(data []byte) (*ClusterConfig, error) {
+	if isNewFormat(data) {
+		var config ClusterConfig
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse new format topology: %w", err)
+		}
+		return &config, nil
+	}
+
+	var old ClusterTopology
+	if err := yaml.Unmarshal(data, &old); err != nil {
+		return nil, fmt.Errorf("failed to parse old format topology: %w", err)
+	}
+	return normalizeOldToClusterConfig(&old), nil
+}
+
+// isNewFormat checks if the YAML contains new-format markers.
+// New format has nodePools with nested gpu.backend fields.
+// Old format has nodePools with flat gpuProduct/gpuCount/gpuMemory fields.
+func isNewFormat(data []byte) bool {
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+
+	nodePools, ok := raw["nodePools"]
+	if !ok {
+		return false
+	}
+
+	poolsMap, ok := nodePools.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	for _, pool := range poolsMap {
+		poolMap, ok := pool.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// If any pool has a "gpu" key, it's new format
+		if _, hasGpu := poolMap["gpu"]; hasGpu {
+			return true
+		}
+		// If any pool has "gpuProduct" or "gpuCount", it's old format
+		if _, hasProduct := poolMap["gpuProduct"]; hasProduct {
+			return false
+		}
+		if _, hasCount := poolMap["gpuCount"]; hasCount {
+			return false
+		}
+	}
+
+	// No pools or empty pools — check for gpuOperator key (new format only)
+	if _, hasOperator := raw["gpuOperator"]; hasOperator {
+		return true
+	}
+
+	// Default to old format for backwards compat
+	return false
 }

--- a/internal/common/topology/normalize.go
+++ b/internal/common/topology/normalize.go
@@ -1,0 +1,54 @@
+package topology
+
+// normalizeOldToClusterConfig converts the old ClusterTopology format into the
+// new ClusterConfig format. This enables backwards compatibility: users can keep
+// using the old topology: values.yaml format and it gets normalized at read time.
+func normalizeOldToClusterConfig(old *ClusterTopology) *ClusterConfig {
+	config := &ClusterConfig{
+		NodePoolLabelKey: old.NodePoolLabelKey,
+		MigStrategy:      old.MigStrategy,
+		NodePools:        make(map[string]NodePoolConfig, len(old.NodePools)),
+	}
+
+	for name, pool := range old.NodePools {
+		config.NodePools[name] = normalizeNodePool(pool)
+	}
+
+	return config
+}
+
+func normalizeNodePool(old NodePoolTopology) NodePoolConfig {
+	deviceDefaults := map[string]interface{}{
+		"name": old.GpuProduct,
+		"memory": map[string]interface{}{
+			"total_bytes": int64(old.GpuMemory) * 1024 * 1024,
+		},
+	}
+
+	devices := make([]interface{}, old.GpuCount)
+	for i := range devices {
+		devices[i] = map[string]interface{}{}
+	}
+
+	overrides := map[string]interface{}{
+		"device_defaults": deviceDefaults,
+		"devices":         devices,
+	}
+
+	poolConfig := NodePoolConfig{
+		Gpu: GpuConfig{
+			Backend:   "fake",
+			Overrides: overrides,
+		},
+	}
+
+	if len(old.OtherDevices) > 0 {
+		resources := make([]map[string]int, len(old.OtherDevices))
+		for i, dev := range old.OtherDevices {
+			resources[i] = map[string]int{dev.Name: dev.Count}
+		}
+		poolConfig.Resources = resources
+	}
+
+	return poolConfig
+}

--- a/internal/common/topology/normalize.go
+++ b/internal/common/topology/normalize.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"bytes"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -63,6 +64,10 @@ func normalizeNodePool(old NodePoolTopology) NodePoolConfig {
 // returns a ClusterConfig. It auto-detects whether the data is in old (ClusterTopology)
 // or new (ClusterConfig) format.
 func ParseAndNormalizeTopology(data []byte) (*ClusterConfig, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("topology data is empty")
+	}
+
 	if isNewFormat(data) {
 		var config ClusterConfig
 		if err := yaml.Unmarshal(data, &config); err != nil {
@@ -115,7 +120,7 @@ func isNewFormat(data []byte) bool {
 		}
 	}
 
-	// No pools or empty pools — check for gpuOperator key (new format only)
+	// No discriminating keys found — check for gpuOperator key (new format only)
 	if _, hasOperator := raw["gpuOperator"]; hasOperator {
 		return true
 	}

--- a/internal/common/topology/normalize_test.go
+++ b/internal/common/topology/normalize_test.go
@@ -1,0 +1,115 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeOldFormatToClusterConfig(t *testing.T) {
+	old := &ClusterTopology{
+		NodePoolLabelKey: "run.ai/simulated-gpu-node-pool",
+		MigStrategy:      "mixed",
+		NodePools: map[string]NodePoolTopology{
+			"default": {
+				GpuCount:   2,
+				GpuMemory:  11441,
+				GpuProduct: "Tesla-K80",
+			},
+		},
+	}
+
+	config := normalizeOldToClusterConfig(old)
+
+	assert.Equal(t, "run.ai/simulated-gpu-node-pool", config.NodePoolLabelKey)
+	assert.Equal(t, "mixed", config.MigStrategy)
+	assert.Nil(t, config.GpuOperator)
+
+	require.Contains(t, config.NodePools, "default")
+	pool := config.NodePools["default"]
+
+	assert.Equal(t, "fake", pool.Gpu.Backend)
+	assert.Empty(t, pool.Gpu.Profile)
+
+	// gpuProduct → overrides.device_defaults.name
+	deviceDefaults := pool.Gpu.Overrides["device_defaults"].(map[string]interface{})
+	assert.Equal(t, "Tesla-K80", deviceDefaults["name"])
+
+	// gpuMemory (MiB) → overrides.device_defaults.memory.total_bytes (bytes)
+	memory := deviceDefaults["memory"].(map[string]interface{})
+	assert.Equal(t, int64(11441)*1024*1024, memory["total_bytes"])
+
+	// gpuCount → overrides.devices (list of N empty items)
+	devices := pool.Gpu.Overrides["devices"].([]interface{})
+	assert.Len(t, devices, 2)
+}
+
+func TestNormalizeOldFormatWithOtherDevices(t *testing.T) {
+	old := &ClusterTopology{
+		NodePoolLabelKey: "run.ai/simulated-gpu-node-pool",
+		MigStrategy:      "none",
+		NodePools: map[string]NodePoolTopology{
+			"rdma-pool": {
+				GpuCount:   4,
+				GpuMemory:  40960,
+				GpuProduct: "NVIDIA-A100-SXM4-40GB",
+				OtherDevices: []GenericDevice{
+					{Name: "rdma/rdma_shared_device_a", Count: 1},
+					{Name: "vpc.amazonaws.com/efa", Count: 4},
+				},
+			},
+		},
+	}
+
+	config := normalizeOldToClusterConfig(old)
+	pool := config.NodePools["rdma-pool"]
+
+	// otherDevices → resources ([]map[string]int)
+	require.Len(t, pool.Resources, 2)
+	assert.Equal(t, map[string]int{"rdma/rdma_shared_device_a": 1}, pool.Resources[0])
+	assert.Equal(t, map[string]int{"vpc.amazonaws.com/efa": 4}, pool.Resources[1])
+}
+
+func TestNormalizeOldFormatZeroGpuCount(t *testing.T) {
+	old := &ClusterTopology{
+		NodePoolLabelKey: "run.ai/simulated-gpu-node-pool",
+		MigStrategy:      "none",
+		NodePools: map[string]NodePoolTopology{
+			"empty": {
+				GpuCount:   0,
+				GpuMemory:  0,
+				GpuProduct: "",
+			},
+		},
+	}
+
+	config := normalizeOldToClusterConfig(old)
+	pool := config.NodePools["empty"]
+
+	assert.Equal(t, "fake", pool.Gpu.Backend)
+	devices := pool.Gpu.Overrides["devices"].([]interface{})
+	assert.Len(t, devices, 0)
+}
+
+func TestNormalizeOldFormatEmptyNodePools(t *testing.T) {
+	old := &ClusterTopology{
+		NodePoolLabelKey: "run.ai/simulated-gpu-node-pool",
+		MigStrategy:      "none",
+		NodePools:        map[string]NodePoolTopology{},
+	}
+
+	config := normalizeOldToClusterConfig(old)
+	assert.Empty(t, config.NodePools)
+}
+
+func TestNormalizeOldFormatNilNodePools(t *testing.T) {
+	old := &ClusterTopology{
+		NodePoolLabelKey: "run.ai/simulated-gpu-node-pool",
+		MigStrategy:      "none",
+		NodePools:        nil,
+	}
+
+	config := normalizeOldToClusterConfig(old)
+	assert.Empty(t, config.NodePools)
+}

--- a/internal/common/topology/normalize_test.go
+++ b/internal/common/topology/normalize_test.go
@@ -94,6 +94,53 @@ func TestNormalizeOldFormatZeroGpuCount(t *testing.T) {
 	assert.Len(t, devices, 0)
 }
 
+func TestNormalizeOldFormatMultiplePools(t *testing.T) {
+	old := &ClusterTopology{
+		NodePoolLabelKey: "run.ai/simulated-gpu-node-pool",
+		MigStrategy:      "mixed",
+		NodePools: map[string]NodePoolTopology{
+			"a100-pool": {
+				GpuCount:   8,
+				GpuMemory:  40960,
+				GpuProduct: "NVIDIA-A100-SXM4-40GB",
+				OtherDevices: []GenericDevice{
+					{Name: "rdma/rdma_shared_device_a", Count: 1},
+				},
+			},
+			"t4-pool": {
+				GpuCount:   2,
+				GpuMemory:  16384,
+				GpuProduct: "Tesla-T4",
+			},
+			"cpu-only": {
+				GpuCount:   0,
+				GpuMemory:  0,
+				GpuProduct: "",
+			},
+		},
+	}
+
+	config := normalizeOldToClusterConfig(old)
+
+	require.Len(t, config.NodePools, 3)
+
+	a100 := config.NodePools["a100-pool"]
+	assert.Equal(t, "fake", a100.Gpu.Backend)
+	assert.Len(t, a100.Gpu.Overrides["devices"].([]interface{}), 8)
+	dd := a100.Gpu.Overrides["device_defaults"].(map[string]interface{})
+	assert.Equal(t, "NVIDIA-A100-SXM4-40GB", dd["name"])
+	assert.Equal(t, int64(40960)*1024*1024, dd["memory"].(map[string]interface{})["total_bytes"])
+	require.Len(t, a100.Resources, 1)
+	assert.Equal(t, map[string]int{"rdma/rdma_shared_device_a": 1}, a100.Resources[0])
+
+	t4 := config.NodePools["t4-pool"]
+	assert.Len(t, t4.Gpu.Overrides["devices"].([]interface{}), 2)
+	assert.Nil(t, t4.Resources)
+
+	cpuOnly := config.NodePools["cpu-only"]
+	assert.Len(t, cpuOnly.Gpu.Overrides["devices"].([]interface{}), 0)
+}
+
 func TestNormalizeOldFormatEmptyNodePools(t *testing.T) {
 	old := &ClusterTopology{
 		NodePoolLabelKey: "run.ai/simulated-gpu-node-pool",

--- a/internal/common/topology/normalize_test.go
+++ b/internal/common/topology/normalize_test.go
@@ -184,6 +184,16 @@ func TestParseAndNormalizeInvalidYAML(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParseAndNormalizeEmptyInput(t *testing.T) {
+	_, err := ParseAndNormalizeTopology([]byte(""))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+
+	_, err = ParseAndNormalizeTopology([]byte("   \n  "))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
 func TestFromClusterConfigCM_OldFormat(t *testing.T) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "topology", Namespace: "gpu-operator"},

--- a/internal/common/topology/normalize_test.go
+++ b/internal/common/topology/normalize_test.go
@@ -113,3 +113,71 @@ func TestNormalizeOldFormatNilNodePools(t *testing.T) {
 	config := normalizeOldToClusterConfig(old)
 	assert.Empty(t, config.NodePools)
 }
+
+func TestDetectFormatOld(t *testing.T) {
+	yamlData := `
+nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+migStrategy: mixed
+nodePools:
+  default:
+    gpuProduct: Tesla-K80
+    gpuCount: 2
+    gpuMemory: 11441
+`
+	config, err := ParseAndNormalizeTopology([]byte(yamlData))
+	require.NoError(t, err)
+	assert.Equal(t, "run.ai/simulated-gpu-node-pool", config.NodePoolLabelKey)
+	assert.Equal(t, "fake", config.NodePools["default"].Gpu.Backend)
+}
+
+func TestDetectFormatNew(t *testing.T) {
+	yamlData := `
+nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+migStrategy: mixed
+nodePools:
+  pool-a:
+    gpu:
+      backend: fake
+      profile: h100
+      overrides:
+        device_defaults:
+          name: "Custom H100"
+    resources:
+      - rdma/rdma_shared_device_a: 1
+`
+	config, err := ParseAndNormalizeTopology([]byte(yamlData))
+	require.NoError(t, err)
+	assert.Equal(t, "run.ai/simulated-gpu-node-pool", config.NodePoolLabelKey)
+
+	pool := config.NodePools["pool-a"]
+	assert.Equal(t, "fake", pool.Gpu.Backend)
+	assert.Equal(t, "h100", pool.Gpu.Profile)
+	assert.Equal(t, "Custom H100", pool.Gpu.Overrides["device_defaults"].(map[string]interface{})["name"])
+}
+
+func TestDetectFormatNewWithGpuOperator(t *testing.T) {
+	yamlData := `
+nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+migStrategy: mixed
+gpuOperator:
+  version: v24.9.0
+  values:
+    dcgmExporter:
+      enabled: true
+nodePools:
+  pool-b:
+    gpu:
+      backend: mock
+      profile: a100
+`
+	config, err := ParseAndNormalizeTopology([]byte(yamlData))
+	require.NoError(t, err)
+	require.NotNil(t, config.GpuOperator)
+	assert.Equal(t, "v24.9.0", config.GpuOperator.Version)
+	assert.Equal(t, "mock", config.NodePools["pool-b"].Gpu.Backend)
+}
+
+func TestParseAndNormalizeInvalidYAML(t *testing.T) {
+	_, err := ParseAndNormalizeTopology([]byte(`{{{not yaml`))
+	assert.Error(t, err)
+}

--- a/internal/common/topology/normalize_test.go
+++ b/internal/common/topology/normalize_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNormalizeOldFormatToClusterConfig(t *testing.T) {
@@ -180,4 +182,58 @@ nodePools:
 func TestParseAndNormalizeInvalidYAML(t *testing.T) {
 	_, err := ParseAndNormalizeTopology([]byte(`{{{not yaml`))
 	assert.Error(t, err)
+}
+
+func TestFromClusterConfigCM_OldFormat(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "topology", Namespace: "gpu-operator"},
+		Data: map[string]string{
+			CmTopologyKey: `
+nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+migStrategy: mixed
+nodePools:
+  default:
+    gpuProduct: Tesla-K80
+    gpuCount: 2
+    gpuMemory: 11441
+`,
+		},
+	}
+
+	config, err := FromClusterConfigCM(cm)
+	require.NoError(t, err)
+	assert.Equal(t, "mixed", config.MigStrategy)
+	assert.Equal(t, "fake", config.NodePools["default"].Gpu.Backend)
+}
+
+func TestFromClusterConfigCM_NewFormat(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "topology", Namespace: "gpu-operator"},
+		Data: map[string]string{
+			CmTopologyKey: `
+nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+migStrategy: mixed
+nodePools:
+  pool-a:
+    gpu:
+      backend: fake
+      profile: h100
+`,
+		},
+	}
+
+	config, err := FromClusterConfigCM(cm)
+	require.NoError(t, err)
+	assert.Equal(t, "h100", config.NodePools["pool-a"].Gpu.Profile)
+}
+
+func TestFromClusterConfigCM_MissingKey(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "topology", Namespace: "gpu-operator"},
+		Data:       map[string]string{},
+	}
+
+	_, err := FromClusterConfigCM(cm)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing key")
 }

--- a/internal/common/topology/types.go
+++ b/internal/common/topology/types.go
@@ -18,6 +18,31 @@ type NodePoolTopology struct {
 	OtherDevices []GenericDevice `yaml:"otherDevices"`
 }
 
+// ClusterConfig is the new top-level config structure (cluster: key in topology CM).
+// Used alongside ClusterTopology during migration; callers switch in Phase 3.
+type ClusterConfig struct {
+	NodePoolLabelKey string                    `yaml:"nodePoolLabelKey"`
+	MigStrategy      string                    `yaml:"migStrategy"`
+	NodePools        map[string]NodePoolConfig  `yaml:"nodePools"`
+	GpuOperator      *GpuOperatorConfig         `yaml:"gpuOperator,omitempty"`
+}
+
+type NodePoolConfig struct {
+	Gpu       GpuConfig          `yaml:"gpu"`
+	Resources []map[string]int   `yaml:"resources,omitempty"`
+}
+
+type GpuConfig struct {
+	Backend   string                 `yaml:"backend"`
+	Profile   string                 `yaml:"profile,omitempty"`
+	Overrides map[string]interface{} `yaml:"overrides,omitempty"`
+}
+
+type GpuOperatorConfig struct {
+	Version string                 `yaml:"version,omitempty"`
+	Values  map[string]interface{} `yaml:"values,omitempty"`
+}
+
 type NodeTopology struct {
 	GpuMemory    int             `yaml:"gpuMemory"`
 	GpuProduct   string          `yaml:"gpuProduct"`


### PR DESCRIPTION
## Summary

Phase 1 of the new FGO Values API redesign ([RUN-38191](https://runai.atlassian.net/browse/RUN-38191)).

- Add new `ClusterConfig`, `NodePoolConfig`, `GpuConfig`, `GpuOperatorConfig` Go types alongside existing `ClusterTopology`
- Implement backwards-compatible normalization: old `topology:` format auto-converts to new `ClusterConfig` at read time
- Auto-detect format via `isNewFormat()` heuristic (checks for `gpu.backend` vs `gpuProduct`/`gpuCount` keys)
- Add `GetClusterConfigFromCM()` / `FromClusterConfigCM()` — new entry points that handle both formats transparently
- Update Helm `topology-cm.yml` to accept either `topology:` or `cluster:` values key

Existing `GetClusterTopologyFromCM()` is unchanged — callers migrate in Phase 3.

## Normalization rules

| Old field | New location |
|---|---|
| `topology.nodePoolLabelKey` | `cluster.nodePoolLabelKey` |
| `topology.migStrategy` | `cluster.migStrategy` |
| `topology.nodePools.X.gpuProduct` | `cluster.nodePools.X.gpu.overrides.device_defaults.name` |
| `topology.nodePools.X.gpuMemory` | `cluster.nodePools.X.gpu.overrides.device_defaults.memory.total_bytes` (MiB → bytes) |
| `topology.nodePools.X.gpuCount` | `cluster.nodePools.X.gpu.overrides.devices` (list of N items) |
| `topology.nodePools.X.otherDevices` | `cluster.nodePools.X.resources` |

## Test plan

- [x] 14 unit tests covering normalization, format detection, ConfigMap round-trip, edge cases
- [x] Multi-pool normalization test (A100+RDMA, T4, CPU-only)
- [x] Empty/invalid input error handling
- [x] Helm template verified with both old and new format values
- [x] E2E on kind: install old format → upgrade to new format → rollback — all correct
- [x] All existing tests pass (no regressions)
- [x] All components build

[RUN-38191]: https://runai.atlassian.net/browse/RUN-38191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ