### PR TITLE
docs(changelog): backfill entries for #193 and #194

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   format. PRs should add an entry here under `## [Unreleased]` unless the
   `skip-changelog` label is applied.
+- Mock backend for per-pool `nvml-mock` integration: nodes in pools with
+  `gpu.backend: mock` get a profile-driven `nvml-mock` DaemonSet plus
+  ConfigMap, exposing a real `libnvidia-ml.so` so the upstream NVIDIA
+  device-plugin and DRA driver enumerate synthetic GPUs through NVML.
+  Toggles via new `gpuOperator.enabled` / `nvidiaDraDriver.enabled` chart
+  subcharts. See `docs/mock-backend.md`.
+  ([RUN-38195](https://runai.atlassian.net/browse/RUN-38195))
+- KIND-based mock-pool e2e suite (`make e2e-mock`) covering the
+  device-plugin path, DRA path, multi-pool differentiation, profile
+  overrides, and fake/mock coexistence. Wired into CI as a release gate.
+  ([RUN-38195](https://runai.atlassian.net/browse/RUN-38195))
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Backfills `CHANGELOG.md` entries under `[Unreleased]` for two recently merged PRs that shipped without changelog notes:

- **#193** — Phase 5 mock backend (controller + chart wiring + profile system) ([RUN-38195](https://runai.atlassian.net/browse/RUN-38195))
- **#194** — KIND-based mock-pool e2e suite + CI gate ([RUN-38195](https://runai.atlassian.net/browse/RUN-38195))

Both are user-visible (new chart toggles + new release gate), so they belong in the changelog per the repo's per-PR convention documented in the file itself.

## Test plan

- [x] `git diff` confirms two new bullets under `## [Unreleased] / Added`
- [x] Format matches existing entries (indented continuation lines, Jira link suffix)
- [ ] CI green (no code changes, but the lint/test/e2e gates should pass trivially)

[RUN-38195]: https://runai.atlassian.net/browse/RUN-38195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-38195]: https://runai.atlassian.net/browse/RUN-38195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ