### PR TITLE
fix(status-updater): add watch verb on configmaps in RBAC (RUN-38195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+
+- `status-updater` mock controller emitting constant `configmaps "topology"
+  is forbidden: cannot watch` errors. The chart's `fake-status-updater`
+  ClusterRole was missing the `watch` verb on `configmaps`, so the informer
+  added in Phase 5 (mock backend) could never establish a watch and fell
+  back to polling-style reconciles.
+  ([RUN-38195](https://runai.atlassian.net/browse/RUN-38195))

--- a/deploy/fake-gpu-operator/templates/status-updater/clusterrole.yaml
+++ b/deploy/fake-gpu-operator/templates/status-updater/clusterrole.yaml
@@ -32,6 +32,7 @@ rules:
       - create
       - list
       - delete
+      - watch
   - apiGroups:
       - scheduling.run.ai
     resources:


### PR DESCRIPTION
## Summary

One-line RBAC fix. The Phase 5 mock controller's informer (added in #193) subscribes to the `topology` ConfigMap, but the chart's `fake-status-updater` ClusterRole only grants `get/list/update/patch/create/delete` on configmaps — `watch` was missing. Result: every install emits constant

```
configmaps "topology" is forbidden: User "system:serviceaccount:gpu-operator:status-updater" cannot watch resource "configmaps"
```

and the controller falls back to polling-style reconciles.

Cosmetic today on fake-only clusters (the mock controller has nothing to reconcile when there are no `backend: mock` pools), but functional once mock backend is enabled.

## How I verified

1. `helm install fake-gpu-operator --version 0.0.64` + 3 KWOK nodes (legacy install).
2. `helm upgrade --version 0.0.0-5ec82f4 -f same-values.yaml` → reproduces the `cannot watch` log spam.
3. Apply the patched ClusterRole manually (`kubectl patch clusterrole fake-status-updater --type=json -p='[{"op":"add","path":"/rules/2/verbs/-","value":"watch"}]'`) + `kubectl rollout restart deploy/status-updater` → log spam stops, informer establishes its watch cleanly.

## Test plan

- [x] `helm template` renders the updated ClusterRole with `watch` on configmaps
- [x] `make lint` clean
- [x] Live KIND verification of the full `0.0.64 → main` upgrade path

## Out of scope (split intentionally)

The same upgrade path also leaves orphan `nvidia-dcgm-exporter-kwok-gpu-node-*` Deployments behind — runtime-cloned by the pre-#170 `status-updater` from the chart's `replicas: 0` template, never owned by Helm. Cleanup is a one-line `kubectl` per cluster:

```bash
kubectl delete deploy -n gpu-operator \
  -l app=nvidia-dcgm-exporter,component=status-exporter \
  --field-selector metadata.name!=nvidia-dcgm-exporter,metadata.name!=nvidia-dcgm-exporter-kwok
```

That belongs in the chart's upgrade notes, not in this PR.

## Links

- Epic: [RUN-38195](https://runai.atlassian.net/browse/RUN-38195)
- Related: #195 / RUN-39195 (upgrade-e2e — would have caught this in CI)

[RUN-38195]: https://runai.atlassian.net/browse/RUN-38195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ