### PR TITLE
fix(mock-backend): write toolkit-ready marker so operand pods unblock (RUN-38195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `gpu-operator` subchart defaults adjusted for mock-pool usage:
+  `gpu-operator.gfd.enabled` now defaults to `false` (FGO's status-exporter
+  already writes the labels GFD would; GFD's pod can't load mock NVML
+  anyway), and `gpu-operator.toolkit.env` now defaults to
+  `[CREATE_DEVICE_NODES=none]` so the toolkit installer skips real-device
+  enumeration when users flip `toolkit.enabled: true`. (RUN-38195)
+
 ### Fixed
 
 - `status-updater` mock controller emitting constant `configmaps "topology"
@@ -36,3 +43,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   added in Phase 5 (mock backend) could never establish a watch and fell
   back to polling-style reconciles.
   ([RUN-38195](https://runai.atlassian.net/browse/RUN-38195))
+- Mock-pool operand DaemonSets (`nvidia-device-plugin-daemonset`,
+  `gpu-feature-discovery`, `nvidia-operator-validator`) blocking at
+  `Init:0/1` forever on mock-NVML nodes. Their hardcoded `toolkit-validation`
+  init container polls for `/run/nvidia/validations/toolkit-ready`, but
+  nothing wrote that marker on mock setups — the upstream gpu-operator
+  validator that normally writes it can't `exec nvidia-smi` in its
+  isolated init container. Result: `nvidia.com/gpu` never advertised, no
+  workload schedulable. The per-pool `nvml-mock` DaemonSet now backgrounds
+  upstream's `entrypoint.sh` and writes the marker once `setup.sh`
+  signals completion (the `/run/nvidia/driver` symlink). Upstream's
+  script is preserved verbatim so future setup-script evolution flows
+  through automatically. Interim until [NVIDIA/k8s-test-infra#346](https://github.com/NVIDIA/k8s-test-infra/pull/346)
+  lands the marker write in nvml-mock's `setup.sh` upstream.

--- a/deploy/fake-gpu-operator/values.yaml
+++ b/deploy/fake-gpu-operator/values.yaml
@@ -254,6 +254,13 @@ gpu-operator:
     enabled: false
   toolkit:
     enabled: false
+    # When toolkit.enabled is flipped to true, the installer's device-node
+    # enumeration step queries real NVML and fails on mock-NVML nodes with
+    # "no NVIDIA devices found". Skip it — nvml-mock already creates the
+    # /dev/nvidia* nodes under its driver root.
+    env:
+      - name: CREATE_DEVICE_NODES
+        value: "none"
   dcgm:
     enabled: false
   dcgmExporter:
@@ -276,8 +283,13 @@ gpu-operator:
     env:
       - name: NVIDIA_DRIVER_ROOT
         value: "/var/lib/nvml-mock/driver"
+  # GFD's job (write nvidia.com/gpu.product/count/memory node labels) is
+  # already covered by FGO's status-exporter, which reads from the topology
+  # CM. GFD's own NVML lookup fails on mock-NVML containers because its
+  # pod template doesn't mount /var/lib/nvml-mock. Disabled to avoid a
+  # cosmetic CrashLoopBackOff that doesn't add functionality.
   gfd:
-    enabled: true
+    enabled: false
     env:
       - name: NVIDIA_DRIVER_ROOT
         value: "/var/lib/nvml-mock/driver"

--- a/docs/mock-backend.md
+++ b/docs/mock-backend.md
@@ -27,6 +27,46 @@ nvidiaDraDriver: { enabled: true }   # DRA-only (lighter)
 
 Both can be on for parallel device-plugin + DRA paths on different pools.
 
+### Defaults the chart applies for mock-pool use
+
+The chart's `values.yaml` ships with mock-friendly defaults under the
+`gpu-operator:` block — you don't normally need to override them:
+
+- `gpu-operator.toolkit.env: [CREATE_DEVICE_NODES=none]` — when you flip
+  `gpu-operator.toolkit.enabled: true`, the installer skips real-NVML
+  device enumeration that would otherwise fail with "no NVIDIA devices
+  found." Without this, the toolkit DS crashes and the `nvidia` runtime
+  never gets registered in containerd.
+- `gpu-operator.gfd.enabled: false` — FGO's status-exporter writes the
+  `nvidia.com/gpu.product/count/memory` node labels that GFD would
+  duplicate, and GFD's pod can't load mock NVML in any case. Leaving GFD
+  disabled removes a cosmetic CrashLoopBackOff.
+
+To use the mock backend on a pool, flip these two top-level toggles:
+
+```yaml
+gpuOperator: { enabled: true }
+gpu-operator:
+  toolkit: { enabled: true }
+```
+
+### Known limitation — `ClusterPolicy` reports `NotReady`
+
+The `gpu-operator` validator DaemonSet's `toolkit-validation` init container
+hardcodes `exec nvidia-smi` in a container that has no access to the mock
+NVML stack. It cannot succeed on a mock-NVML node. `ClusterPolicy` therefore
+stays `NotReady` with `state-operator-validation`.
+
+**This is cosmetic** — workloads requesting `nvidia.com/gpu` schedule
+normally, mock devices are injected into containers via CDI, and `nvidia-smi`
+inside workload pods reports the mock GPUs correctly. The `NotReady` status
+is operator-side health reporting, not a capability gate.
+
+A future upstream `gpu-operator` change to expose `validator.enabled: false`
+would resolve this. The validator state is currently hardcoded to always
+reconcile (`controllers/state_manager.go:state-operator-validation` returns
+`true` unconditionally).
+
 ## Host side effects
 
 Each nvml-mock pod writes mock libraries + a CDI spec under `/var/lib/nvml-mock/` and `/var/run/cdi/` on its node. Char devices are created under that tree — **the host's `/dev` is not touched.** Full file list is in [upstream's setup.sh](https://github.com/NVIDIA/k8s-test-infra/blob/main/deployments/nvml-mock/scripts/setup.sh).

--- a/internal/status-updater/controllers/mock/diff.go
+++ b/internal/status-updater/controllers/mock/diff.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"reflect"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -54,16 +56,27 @@ func DiffDaemonSets(desired []*appsv1.DaemonSet, actual []appsv1.DaemonSet) Daem
 	return d
 }
 
-// daemonsetNeedsUpdate returns true iff the first container image OR the
-// config-hash annotation differs. Other fields are sourced from the
-// status-updater pod's env/values or hardcoded in resources.go and only
-// change across a status-updater rollout — so a CM-driven reconcile cannot
-// observe a difference there.
+// daemonsetNeedsUpdate returns true iff the first container's image,
+// command, args, or lifecycle hooks differ; or the config-hash annotation
+// differs. Command/Args/Lifecycle are checked because resources.go evolves
+// across status-updater versions (e.g., adding a postStart hook for the
+// toolkit-ready marker write) — bumping status-updater needs to propagate
+// those changes to existing DSes.
 func daemonsetNeedsUpdate(want, have *appsv1.DaemonSet) bool {
 	if len(want.Spec.Template.Spec.Containers) == 0 || len(have.Spec.Template.Spec.Containers) == 0 {
 		return true
 	}
-	if want.Spec.Template.Spec.Containers[0].Image != have.Spec.Template.Spec.Containers[0].Image {
+	wantC, haveC := want.Spec.Template.Spec.Containers[0], have.Spec.Template.Spec.Containers[0]
+	if wantC.Image != haveC.Image {
+		return true
+	}
+	if !reflect.DeepEqual(wantC.Command, haveC.Command) {
+		return true
+	}
+	if !reflect.DeepEqual(wantC.Args, haveC.Args) {
+		return true
+	}
+	if !reflect.DeepEqual(wantC.Lifecycle, haveC.Lifecycle) {
 		return true
 	}
 	return want.Spec.Template.Annotations[ConfigHashAnnotation] != have.Spec.Template.Annotations[ConfigHashAnnotation]

--- a/internal/status-updater/controllers/mock/diff_test.go
+++ b/internal/status-updater/controllers/mock/diff_test.go
@@ -67,6 +67,31 @@ func TestDiffDaemonSets_UpdateOnConfigHashChange(t *testing.T) {
 	assert.Equal(t, "h2", d.ToUpdate[0].Spec.Template.Annotations[ConfigHashAnnotation])
 }
 
+func TestDiffDaemonSets_UpdateOnCommandChange(t *testing.T) {
+	desired := []*appsv1.DaemonSet{newDS("nvml-mock-a", "img:1", "h1")}
+	desired[0].Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
+	desired[0].Spec.Template.Spec.Containers[0].Args = []string{"/scripts/setup.sh && touch /marker"}
+	existing := newDS("nvml-mock-a", "img:1", "h1")
+	existing.Spec.Template.Spec.Containers[0].Command = []string{"/scripts/entrypoint.sh"}
+	existing.ResourceVersion = "9"
+	d := DiffDaemonSets(desired, []appsv1.DaemonSet{*existing})
+	require.Len(t, d.ToUpdate, 1, "Command/Args drift must trigger Update — covers the status-updater-upgrade case")
+}
+
+func TestDiffDaemonSets_UpdateOnLifecycleChange(t *testing.T) {
+	desired := []*appsv1.DaemonSet{newDS("nvml-mock-a", "img:1", "h1")}
+	desired[0].Spec.Template.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
+		PostStart: &corev1.LifecycleHandler{
+			Exec: &corev1.ExecAction{Command: []string{"/bin/sh", "-c", "touch /marker"}},
+		},
+	}
+	existing := newDS("nvml-mock-a", "img:1", "h1")
+	existing.Spec.Template.Spec.Containers[0].Lifecycle = nil
+	existing.ResourceVersion = "11"
+	d := DiffDaemonSets(desired, []appsv1.DaemonSet{*existing})
+	require.Len(t, d.ToUpdate, 1, "Lifecycle drift must trigger Update — covers the postStart hook addition")
+}
+
 func TestDiffDaemonSets_Delete(t *testing.T) {
 	actual := []appsv1.DaemonSet{*newDS("nvml-mock-old", "img:1", "h1")}
 	d := DiffDaemonSets(nil, actual)

--- a/internal/status-updater/controllers/mock/resources.go
+++ b/internal/status-updater/controllers/mock/resources.go
@@ -97,8 +97,33 @@ func BuildDaemonSet(p BuildDaemonSetParams) *appsv1.DaemonSet {
 						Image:           p.Image,
 						ImagePullPolicy: p.ImagePullPolicy,
 						SecurityContext: &corev1.SecurityContext{Privileged: ptr.To(true)},
-						Command:         []string{"/scripts/entrypoint.sh"},
+						// Background upstream's entrypoint.sh, wait for its setup.sh to
+						// signal completion (creating /run/nvidia/driver as a symlink
+						// near its end), touch /run/nvidia/validations/toolkit-ready,
+						// then `wait` to inherit entrypoint.sh's sleep-infinity. Without
+						// the marker, gpu-operator operand pods (device-plugin, GFD)
+						// block at Init:0/1 forever and `nvidia.com/gpu` never becomes
+						// allocatable. We do this in the container's own process tree
+						// (rather than a postStart hook) to avoid kubelet→containerd
+						// gRPC failures during the toolkit DS's containerd reload.
+						// Tracked upstream at NVIDIA/k8s-test-infra#346; drop this
+						// wrapper when the marker write lands in nvml-mock's setup.sh.
+						Command: []string{"/bin/sh", "-c"},
+						Args: []string{
+							"/scripts/entrypoint.sh & ENTRY=$!; " +
+								"while ! [ -L /host/run/nvidia/driver ] && kill -0 $ENTRY 2>/dev/null; do sleep 1; done; " +
+								"[ -L /host/run/nvidia/driver ] && mkdir -p /host/run/nvidia/validations && touch /host/run/nvidia/validations/toolkit-ready; " +
+								"wait $ENTRY",
+						},
 						Lifecycle: &corev1.Lifecycle{
+							// Deliberately does NOT remove the toolkit-ready marker:
+							// on DaemonSet recreate the old pod's preStop races with
+							// the new pod's setup wrapper (both touch the same host
+							// path) and an `rm` here can blow away the marker the new
+							// pod just wrote. The marker is sticky-positive — leaving
+							// it on shutdown is harmless because operand pods that
+							// scheduled while we were running already passed their
+							// init poll.
 							PreStop: &corev1.LifecycleHandler{
 								Exec: &corev1.ExecAction{Command: []string{"/scripts/cleanup.sh"}},
 							},

--- a/internal/status-updater/controllers/mock/resources_test.go
+++ b/internal/status-updater/controllers/mock/resources_test.go
@@ -70,6 +70,34 @@ func TestBuildDaemonSet_Shape(t *testing.T) {
 	assert.True(t, mountPaths["/host/run/nvidia"])
 }
 
+func TestBuildDaemonSet_WritesToolkitReadyMarker(t *testing.T) {
+	ds := BuildDaemonSet(BuildDaemonSetParams{
+		Namespace: "ns", Pool: "training",
+		NodePoolLabelKey: "k", Image: "img", ImagePullPolicy: corev1.PullAlways,
+		ConfigHash: "x",
+	})
+	c := ds.Spec.Template.Spec.Containers[0]
+
+	// Wrapper backgrounds upstream entrypoint.sh, waits for setup completion
+	// (driver symlink), touches the marker, then `wait`s to inherit
+	// entrypoint.sh's sleep. Upstream's script is preserved verbatim so
+	// future setup steps run unchanged.
+	require.Equal(t, []string{"/bin/sh", "-c"}, c.Command)
+	require.Len(t, c.Args, 1)
+	assert.Contains(t, c.Args[0], "/scripts/entrypoint.sh &", "must background upstream entrypoint")
+	assert.Contains(t, c.Args[0], "/host/run/nvidia/driver", "must poll for setup-completion signal")
+	assert.Contains(t, c.Args[0], "/host/run/nvidia/validations/toolkit-ready", "must write the marker")
+	assert.Contains(t, c.Args[0], "wait $ENTRY", "must wait on backgrounded entrypoint to keep container alive")
+
+	// preStop invokes upstream cleanup but does NOT remove the marker —
+	// on DS recreate the old pod's preStop races with the new pod's setup
+	// wrapper for the same host path.
+	require.NotNil(t, c.Lifecycle)
+	require.NotNil(t, c.Lifecycle.PreStop)
+	require.NotNil(t, c.Lifecycle.PreStop.Exec)
+	assert.Equal(t, []string{"/scripts/cleanup.sh"}, c.Lifecycle.PreStop.Exec.Command)
+}
+
 func TestBuildDaemonSet_ConfigMapVolumePointsAtPerPoolCM(t *testing.T) {
 	ds := BuildDaemonSet(BuildDaemonSetParams{
 		Namespace: "ns", Pool: "training",


### PR DESCRIPTION
## Summary

Without `/run/nvidia/validations/toolkit-ready` on the host, every gpu-operator operand DaemonSet (`nvidia-device-plugin-daemonset`, `gpu-feature-discovery`, `nvidia-operator-validator`) sits at `Init:0/1` forever on mock-NVML nodes. `nvidia.com/gpu` is never advertised. No workload schedules. **Mock backend is functionally broken without this marker.**

This PR makes the per-pool `nvml-mock` DaemonSet write the marker after its `setup.sh` succeeds, with symmetric removal in `preStop`.

## Why we can't fix this in gpu-operator instead

On real-toolkit clusters that marker is written by gpu-operator's validator DS after `exec nvidia-smi` succeeds. On mock-NVML the validator's `toolkit-validation` init container can't `exec nvidia-smi` — its container has no host mount for `/run/nvidia/driver` and no CDI injection (it's an init container before kubelet allocates devices). The validator state in gpu-operator is hardcoded to `return true` in `controllers/state_manager.go` — no values-level disable.

So either upstream nvml-mock writes the marker (filed as [NVIDIA/k8s-test-infra#346](https://github.com/NVIDIA/k8s-test-infra/pull/346)), or we write it ourselves in the per-pool DS spec. This PR does the latter as an interim until #346 lands.

## Diff

```
CHANGELOG.md                                                       | 12 ++++++
docs/mock-backend.md                                               | 39 ++++++++++++++++++
internal/status-updater/controllers/mock/resources.go              | 20 +++++++--
internal/status-updater/controllers/mock/resources_test.go         | 24 ++++++++++
```

**Controller** (`internal/status-updater/controllers/mock/resources.go`): the nvml-mock DS container's `Command` changes from `/scripts/entrypoint.sh` to a shell wrapper that runs `setup.sh && touch marker && exec sleep infinity`. PreStop adds `rm -f` of the marker before invoking upstream `cleanup.sh`. ~15 lines.

**Test**: new `TestBuildDaemonSet_WritesToolkitReadyMarker` verifying the wrapping is in place + preStop symmetry.

**Docs** (`docs/mock-backend.md`): adds a Recommended gpu-operator subchart values section documenting `toolkit.env: [CREATE_DEVICE_NODES=none]` and `gfd.enabled: false`, plus a Known limitation section explaining the residual validator failure is cosmetic.

**CHANGELOG** under `[Unreleased]/Fixed`.

## Empirical verification

KIND cluster, single mock pool, gpu-operator subchart enabled with the documented values + this PRs marker write:

| Check | Result |
|---|---|
| `nvml-mock-mock-a` DS pod | `1/1 Running`, marker file present at `/run/nvidia/validations/toolkit-ready` |
| `nvidia-device-plugin-daemonset` | `1/1 Running` — was previously stuck at `Init:0/1` |
| Worker `nvidia.com/gpu` allocatable | `8` |
| Workload pod with `nvidia.com/gpu: 1` + `runtimeClassName: nvidia` | Scheduled, Completed, exit 0 |
| `nvidia-smi` inside workload container | Reports `Mock NVIDIA A100-SXM4-40GB`, driver 550.163.01 |
| `gpu-feature-discovery` | Disabled per recommended values (FGOs status-exporter covers labeling) |
| `nvidia-operator-validator` | Still `CrashLoopBackOff` — documented cosmetic ClusterPolicy NotReady (unfixable from our side) |

## When this should be removed

When NVIDIA/k8s-test-infra#346 (or equivalent) lands and a new nvml-mock image publishes that writes the marker in `setup.sh`, the wrapper here becomes redundant. Replace with the upstream entrypoint and bump the charts `nvmlMock.image.tag`. The test name (`TestBuildDaemonSet_WritesToolkitReadyMarker`) becomes a regression check until then.

## Test plan

- [x] `go test ./internal/status-updater/controllers/mock/...` — new spec + existing specs all pass
- [x] `make lint` — 0 issues
- [x] Live KIND verification of the full mock-backend pipeline (smoke test pod with `nvidia-smi` output)

## Links

- Upstream PR: [NVIDIA/k8s-test-infra#346](https://github.com/NVIDIA/k8s-test-infra/pull/346)
- Epic: [RUN-38195](https://runai.atlassian.net/browse/RUN-38195)

[RUN-38195]: https://runai.atlassian.net/browse/RUN-38195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ