### PR TITLE
fix(kwok-dra-plugin): align ResourceSlice + DeviceClass with upstream contract (RUN-39005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `kwok-dra-plugin` ResourceSlices failing upstream `nvidia-dra-driver-gpu`
+  DeviceClass CEL selector on hybrid clusters. Pods requesting
+  `gpu.nvidia.com` ResourceClaims and targeting KWOK fake nodes hit
+  `CEL runtime error: no such key: type` because slices only carried
+  unqualified `uuid`/`model` attributes — upstream's selector reads
+  `device.attributes['gpu.nvidia.com'].type`. The plugin now also emits
+  qualified `gpu.nvidia.com/type=gpu`, `gpu.nvidia.com/uuid`, and
+  `gpu.nvidia.com/productName`, and the chart's own `gpu.nvidia.com`
+  DeviceClass mirrors upstream's CEL + `extendedResourceName` so the
+  contract is identical regardless of whether `nvidiaDraDriver.enabled`
+  is set. (RUN-39005)
 - `status-updater` mock controller emitting constant `configmaps "topology"
   is forbidden: cannot watch` errors. The chart's `fake-status-updater`
   ClusterRole was missing the `watch` verb on `configmaps`, so the informer

--- a/deploy/fake-gpu-operator/templates/dra-device-plugin/templates/deviceclass.yaml
+++ b/deploy/fake-gpu-operator/templates/dra-device-plugin/templates/deviceclass.yaml
@@ -1,11 +1,4 @@
-{{- /*
-  When the upstream nvidia-dra-driver-gpu subchart is enabled it installs
-  its own gpu.nvidia.com DeviceClass with this exact selector. We render
-  ours only when that subchart is OFF, and we mirror its CEL expression
-  and extendedResourceName so the contract is identical across modes —
-  consumers reading ResourceClaims for `gpu.nvidia.com` don't see different
-  scheduling behavior depending on which DeviceClass renders.
-*/ -}}
+{{- /* Mirrors nvidia-dra-driver-gpu's gpu.nvidia.com DeviceClass; rendered only when that subchart is off. */ -}}
 {{- if and (or .Values.draPlugin.enabled .Values.kwokDraPlugin.enabled) (not .Values.nvidiaDraDriver.enabled) -}}
 {{- $resourceApiVersion := include "dra-example-driver.resourceApiVersion" . -}}
 apiVersion: {{ $resourceApiVersion }}

--- a/deploy/fake-gpu-operator/templates/dra-device-plugin/templates/deviceclass.yaml
+++ b/deploy/fake-gpu-operator/templates/dra-device-plugin/templates/deviceclass.yaml
@@ -1,10 +1,22 @@
+{{- /*
+  When the upstream nvidia-dra-driver-gpu subchart is enabled it installs
+  its own gpu.nvidia.com DeviceClass with this exact selector. We render
+  ours only when that subchart is OFF, and we mirror its CEL expression
+  and extendedResourceName so the contract is identical across modes —
+  consumers reading ResourceClaims for `gpu.nvidia.com` don't see different
+  scheduling behavior depending on which DeviceClass renders.
+*/ -}}
 {{- if and (or .Values.draPlugin.enabled .Values.kwokDraPlugin.enabled) (not .Values.nvidiaDraDriver.enabled) -}}
-apiVersion: {{ include "dra-example-driver.resourceApiVersion" . }}
+{{- $resourceApiVersion := include "dra-example-driver.resourceApiVersion" . -}}
+apiVersion: {{ $resourceApiVersion }}
 kind: DeviceClass
 metadata:
   name: gpu.nvidia.com
 spec:
   selectors:
   - cel:
-      expression: "device.driver == 'gpu.nvidia.com'"
+      expression: "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].type == 'gpu'"
+  {{- if eq $resourceApiVersion "resource.k8s.io/v1" }}
+  extendedResourceName: nvidia.com/gpu
+  {{- end }}
 {{- end -}}

--- a/internal/dra-plugin-gpu/discovery.go
+++ b/internal/dra-plugin-gpu/discovery.go
@@ -63,14 +63,8 @@ func enumerateAllPossibleDevices(nodeName string) (AllocatableDevices, error) {
 		// Use ID (UUID) as device name, convert to lowercase for RFC 1123 compliance
 		deviceName := strings.ToLower(gpu.ID)
 
-		// Attributes under the `gpu.nvidia.com` domain satisfy upstream
-		// nvidia-dra-driver-gpu's DeviceClass CEL selector
-		// (`device.attributes['gpu.nvidia.com'].type == 'gpu'`). DRA addresses
-		// `<domain>/<name>` qualified keys as `attributes[<domain>].<name>`
-		// in CEL, so the keys MUST carry the `gpu.nvidia.com/` prefix —
-		// unqualified `type` would resolve to a different namespace and
-		// fail the same selector. Unqualified `uuid` and `model` are kept
-		// for backwards compatibility with any consumer reading them.
+		// gpu.nvidia.com/* keys are required: upstream DeviceClass CEL reads
+		// device.attributes['gpu.nvidia.com'].type. Unqualified uuid/model kept for back-compat.
 		attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 			"uuid": {
 				StringValue: ptr.To(gpu.ID),

--- a/internal/dra-plugin-gpu/discovery.go
+++ b/internal/dra-plugin-gpu/discovery.go
@@ -63,11 +63,28 @@ func enumerateAllPossibleDevices(nodeName string) (AllocatableDevices, error) {
 		// Use ID (UUID) as device name, convert to lowercase for RFC 1123 compliance
 		deviceName := strings.ToLower(gpu.ID)
 
+		// Attributes under the `gpu.nvidia.com` domain satisfy upstream
+		// nvidia-dra-driver-gpu's DeviceClass CEL selector
+		// (`device.attributes['gpu.nvidia.com'].type == 'gpu'`). DRA addresses
+		// `<domain>/<name>` qualified keys as `attributes[<domain>].<name>`
+		// in CEL, so the keys MUST carry the `gpu.nvidia.com/` prefix —
+		// unqualified `type` would resolve to a different namespace and
+		// fail the same selector. Unqualified `uuid` and `model` are kept
+		// for backwards compatibility with any consumer reading them.
 		attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 			"uuid": {
 				StringValue: ptr.To(gpu.ID),
 			},
 			"model": {
+				StringValue: ptr.To(nodeTopology.GpuProduct),
+			},
+			"gpu.nvidia.com/type": {
+				StringValue: ptr.To("gpu"),
+			},
+			"gpu.nvidia.com/uuid": {
+				StringValue: ptr.To(gpu.ID),
+			},
+			"gpu.nvidia.com/productName": {
 				StringValue: ptr.To(nodeTopology.GpuProduct),
 			},
 		}

--- a/internal/kwok-dra-plugin/handlers/resourceslice/handler.go
+++ b/internal/kwok-dra-plugin/handlers/resourceslice/handler.go
@@ -136,11 +136,28 @@ func (h *ResourceSliceHandler) devicesFromTopology(nodeTopology *topology.NodeTo
 		// Use ID (UUID) as device name, convert to lowercase for RFC 1123 compliance
 		deviceName := strings.ToLower(gpu.ID)
 
+		// Attributes under the `gpu.nvidia.com` domain satisfy upstream
+		// nvidia-dra-driver-gpu's DeviceClass CEL selector
+		// (`device.attributes['gpu.nvidia.com'].type == 'gpu'`). DRA addresses
+		// `<domain>/<name>` qualified keys as `attributes[<domain>].<name>`
+		// in CEL, so the keys MUST carry the `gpu.nvidia.com/` prefix —
+		// unqualified `type` would resolve to a different namespace and
+		// fail the same selector. Unqualified `uuid` and `model` are kept
+		// for backwards compatibility with any consumer reading them.
 		attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 			"uuid": {
 				StringValue: ptr.To(gpu.ID),
 			},
 			"model": {
+				StringValue: ptr.To(nodeTopology.GpuProduct),
+			},
+			"gpu.nvidia.com/type": {
+				StringValue: ptr.To("gpu"),
+			},
+			"gpu.nvidia.com/uuid": {
+				StringValue: ptr.To(gpu.ID),
+			},
+			"gpu.nvidia.com/productName": {
 				StringValue: ptr.To(nodeTopology.GpuProduct),
 			},
 		}

--- a/internal/kwok-dra-plugin/handlers/resourceslice/handler.go
+++ b/internal/kwok-dra-plugin/handlers/resourceslice/handler.go
@@ -136,14 +136,8 @@ func (h *ResourceSliceHandler) devicesFromTopology(nodeTopology *topology.NodeTo
 		// Use ID (UUID) as device name, convert to lowercase for RFC 1123 compliance
 		deviceName := strings.ToLower(gpu.ID)
 
-		// Attributes under the `gpu.nvidia.com` domain satisfy upstream
-		// nvidia-dra-driver-gpu's DeviceClass CEL selector
-		// (`device.attributes['gpu.nvidia.com'].type == 'gpu'`). DRA addresses
-		// `<domain>/<name>` qualified keys as `attributes[<domain>].<name>`
-		// in CEL, so the keys MUST carry the `gpu.nvidia.com/` prefix —
-		// unqualified `type` would resolve to a different namespace and
-		// fail the same selector. Unqualified `uuid` and `model` are kept
-		// for backwards compatibility with any consumer reading them.
+		// gpu.nvidia.com/* keys are required: upstream DeviceClass CEL reads
+		// device.attributes['gpu.nvidia.com'].type. Unqualified uuid/model kept for back-compat.
 		attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 			"uuid": {
 				StringValue: ptr.To(gpu.ID),

--- a/internal/kwok-dra-plugin/handlers/resourceslice/handler_test.go
+++ b/internal/kwok-dra-plugin/handlers/resourceslice/handler_test.go
@@ -188,9 +188,17 @@ var _ = Describe("ResourceSliceHandler", func() {
 			Expect(*devices[0].Attributes["uuid"].StringValue).To(Equal("GPU-0001-0001-0001-0001"))
 			Expect(*devices[0].Attributes["model"].StringValue).To(Equal("NVIDIA-A100-SXM4-40GB"))
 
+			// Qualified attributes satisfy upstream nvidia-dra-driver-gpu's
+			// DeviceClass CEL selector (`device.attributes['gpu.nvidia.com'].type == 'gpu'`).
+			Expect(*devices[0].Attributes["gpu.nvidia.com/type"].StringValue).To(Equal("gpu"))
+			Expect(*devices[0].Attributes["gpu.nvidia.com/uuid"].StringValue).To(Equal("GPU-0001-0001-0001-0001"))
+			Expect(*devices[0].Attributes["gpu.nvidia.com/productName"].StringValue).To(Equal("NVIDIA-A100-SXM4-40GB"))
+
 			// Check second device
 			Expect(devices[1].Name).To(Equal("gpu-0002-0002-0002-0002"))
 			Expect(*devices[1].Attributes["uuid"].StringValue).To(Equal("GPU-0002-0002-0002-0002"))
+			Expect(*devices[1].Attributes["gpu.nvidia.com/type"].StringValue).To(Equal("gpu"))
+			Expect(*devices[1].Attributes["gpu.nvidia.com/uuid"].StringValue).To(Equal("GPU-0002-0002-0002-0002"))
 		})
 
 		It("should skip GPUs without ID", func() {


### PR DESCRIPTION
## Summary

On hybrid clusters running both KWOK fake nodes (via this chart's `kwok-dra-plugin`) and the upstream `nvidia-dra-driver-gpu` subchart (`nvidiaDraDriver.enabled: true`), pods requesting a `gpu.nvidia.com` ResourceClaim and targeting a KWOK fake-pool node fail to schedule with:

```
Warning  FailedScheduling  default-scheduler
  running "DynamicResources" filter plugin: class gpu.nvidia.com:
  selector 0: CEL runtime error: no such key: type
```

Root cause: two slightly-different `gpu.nvidia.com` DeviceClass selectors and a kwok-dra-plugin slice that only satisfies the looser one.

| Source | Selector |
|---|---|
| Upstream `nvidia-dra-driver-gpu` (rendered when `nvidiaDraDriver.enabled: true`) | `device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].type == 'gpu'` |
| This chart (rendered when subchart is OFF) | `device.driver == 'gpu.nvidia.com'` |
| `kwok-dra-plugin` slice attributes | `uuid`, `model` (unqualified — different CEL namespace than `gpu.nvidia.com/*`) |

DRA addresses qualified-name attributes as `device.attributes['<domain>'].<name>` in CEL, so a bare `type` key resolves to a different namespace than `gpu.nvidia.com/type` and doesn't satisfy upstream's selector.

## Fix — align both sides

**1. `kwok-dra-plugin` emits qualified attributes** (`internal/kwok-dra-plugin/handlers/resourceslice/handler.go`):

```diff
 attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
     "uuid":                       {StringValue: ptr.To(gpu.ID)},
     "model":                      {StringValue: ptr.To(nodeTopology.GpuProduct)},
+    "gpu.nvidia.com/type":        {StringValue: ptr.To("gpu")},
+    "gpu.nvidia.com/uuid":        {StringValue: ptr.To(gpu.ID)},
+    "gpu.nvidia.com/productName": {StringValue: ptr.To(nodeTopology.GpuProduct)},
 }
```

Existing unqualified `uuid` and `model` are kept for backwards compatibility with any consumer reading them.

**2. Chart's `gpu.nvidia.com` DeviceClass mirrors upstream's selector + `extendedResourceName`** (`deploy/fake-gpu-operator/templates/dra-device-plugin/templates/deviceclass.yaml`):

```diff
-      expression: "device.driver == 'gpu.nvidia.com'"
+      expression: "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].type == 'gpu'"
+  {{- if eq $resourceApiVersion "resource.k8s.io/v1" }}
+  extendedResourceName: nvidia.com/gpu
+  {{- end }}
```

The existing `{{- if ... (not .Values.nvidiaDraDriver.enabled) -}}` gate is unchanged, so the chart's DeviceClass and the subchart's DeviceClass still don't collide — they now just produce selector-equivalent definitions in either mode.

## Net effect

One contract, one set of required attributes. Scheduling behavior on KWOK fake nodes is identical whether the upstream subchart renders the DeviceClass or we do.

## Why both halves together (not just one)

- **Plugin fix alone, no chart change**: fixes hybrid mode (slices now satisfy upstream's stricter selector). Our chart's looser selector also still works. Contract drift persists.
- **Chart fix alone, no plugin change**: BREAKS fake-only — our slices wouldn't satisfy the now-stricter selector either.
- **Both** (this PR): unified contract; fake-only and hybrid both work; future selector tightening upstream won't surprise us.

## Test plan

- [x] `go test ./internal/kwok-dra-plugin/...` — passes (new assertions on `gpu.nvidia.com/*` attributes)
- [x] `make lint` — 0 issues
- [x] `helm template` — DeviceClass renders with the new selector and `extendedResourceName: nvidia.com/gpu` on `resource.k8s.io/v1`-capable clusters
- [x] Verified the existing gating on `not .Values.nvidiaDraDriver.enabled` still prevents double-render

## Out of scope

Extending KWOK ResourceSlice attributes to include `architecture`, `driverVersion`, `cudaComputeCapability`, etc. — those live in `internal/common/profile.GpuSpec` but aren't currently plumbed through `topology.NodeTopology` to the handler. If future upstream selectors tighten to require them, this PR's pattern (extend `handler.go`'s attribute map + mirror selector in our DeviceClass) is straightforward to extend.

## Links

- Jira: RUN-39005
- GitHub issue: #189