### PR TITLE
test(e2e-upgrade): helm-upgrade regression suite (RUN-39195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,33 @@ jobs:
           DOCKER_REPO_BASE: ghcr.io/run-ai/fake-gpu-operator
           DOCKER_BUILDX_PLATFORMS: linux/amd64
 
+  e2e-upgrade:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install kind
+        uses: helm/kind-action@v1.13.0
+        with:
+          install_only: true
+      - name: Run helm-upgrade e2e tests
+        # Installs the published OCI chart (pin tracks env-in-a-click's
+        # fake_gpu_operator_version), then upgrades to the chart on this
+        # branch. Catches the RUN-39195 regression class — templates that
+        # reference top-level values stored values predate (RUN-39195).
+        run: make e2e-upgrade
+        env:
+          DOCKER_TAG: 0.0.0-dev
+          DOCKER_REPO_BASE: ghcr.io/run-ai/fake-gpu-operator
+          DOCKER_BUILDX_PLATFORMS: linux/amd64
+
   set-release-vars:
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || inputs.release_tag != '' }}
     runs-on: ubuntu-latest
@@ -139,7 +166,7 @@ jobs:
 
   release-docker:
     runs-on: ubuntu-latest
-    needs: [set-release-vars, lint, test, e2e, e2e-profiles, e2e-mock]
+    needs: [set-release-vars, lint, test, e2e, e2e-profiles, e2e-mock, e2e-upgrade]
     if: ${{ needs.set-release-vars.outputs.release_version != '' }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,29 @@ jobs:
           DOCKER_BUILDX_PLATFORMS: linux/amd64
 
   e2e-upgrade:
+    name: e2e-upgrade (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Pinned baseline — catches regressions vs. a known-good release that
+          # external users have been running for weeks.
+          - name: pinned-0.0.80
+            baseline: "0.0.80"
+          # Tip of main — catches regressions vs. the very latest released
+          # commit, closing the gap between "shipped to users" and "about to
+          # ship to users."
+          - name: latest-main
+            baseline: resolve-main
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need recent origin/main history for the latest-main lane to walk
+          # back through commits if the newest one's chart hasn't been
+          # published yet (release-helm runs ~5 min after a main merge).
+          fetch-depth: 10
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -133,12 +152,36 @@ jobs:
         uses: helm/kind-action@v1.13.0
         with:
           install_only: true
+      - name: Resolve baseline chart version
+        id: resolve
+        run: |
+          set -eo pipefail
+          if [[ "${{ matrix.baseline }}" != "resolve-main" ]]; then
+            echo "version=${{ matrix.baseline }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Walk last 5 main commits; first one with a pullable chart wins.
+          # release-helm publishes 0.0.0-<7-char-sha> for every push to main.
+          git fetch origin main --depth=10
+          CHART=oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator
+          for SHA in $(git log origin/main --format='%h' --max-count=5); do
+            VERSION="0.0.0-${SHA}"
+            if helm pull "$CHART" --version "$VERSION" --destination /tmp >/dev/null 2>&1; then
+              echo "Resolved latest-main chart: ${VERSION}"
+              echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "  not pullable: ${VERSION}"
+          done
+          echo "ERROR: no published chart found for the last 5 main commits."
+          exit 1
       - name: Run helm-upgrade e2e tests
-        # Installs a pinned published OCI baseline chart, then upgrades to
-        # the chart on this branch. Catches the RUN-39195 regression class —
-        # templates that reference top-level values stored values predate.
+        # Installs the resolved baseline chart, then upgrades to the chart on
+        # this branch. Catches the RUN-39195 regression class — templates
+        # that reference top-level values the baseline's stored values lack.
         run: make e2e-upgrade
         env:
+          BASELINE_CHART_VERSION: ${{ steps.resolve.outputs.version }}
           DOCKER_TAG: 0.0.0-dev
           DOCKER_REPO_BASE: ghcr.io/run-ai/fake-gpu-operator
           DOCKER_BUILDX_PLATFORMS: linux/amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,9 @@ jobs:
         with:
           install_only: true
       - name: Run helm-upgrade e2e tests
-        # Installs the published OCI chart (pin tracks env-in-a-click's
-        # fake_gpu_operator_version), then upgrades to the chart on this
-        # branch. Catches the RUN-39195 regression class — templates that
-        # reference top-level values stored values predate (RUN-39195).
+        # Installs a pinned published OCI baseline chart, then upgrades to
+        # the chart on this branch. Catches the RUN-39195 regression class —
+        # templates that reference top-level values stored values predate.
         run: make e2e-upgrade
         env:
           DOCKER_TAG: 0.0.0-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   device-plugin path, DRA path, multi-pool differentiation, profile
   overrides, and fake/mock coexistence. Wired into CI as a release gate.
   ([RUN-38195](https://runai.atlassian.net/browse/RUN-38195))
-- Helm-upgrade e2e suite (`make e2e-upgrade`) that installs the published
-  OCI baseline (version pinned to env-in-a-click's
-  `fake_gpu_operator_version`) and then upgrades to the chart on the
+- Helm-upgrade e2e suite (`make e2e-upgrade`) that installs a pinned
+  published OCI baseline chart and then upgrades to the chart on the
   current branch with the same values. Catches the regression class
   where a new top-level chart value gets referenced unsafely in a
   template and breaks `helm upgrade` for users whose stored values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   current branch with the same values. Catches the regression class
   where a new top-level chart value gets referenced unsafely in a
   template and breaks `helm upgrade` for users whose stored values
-  predate that key. Wired into CI as a release gate. (RUN-39195)
+  predate that key. In CI runs as a matrix with two baselines — the
+  pinned release and the latest published `main` chart (via
+  `make e2e-upgrade-from-main` locally) — so regressions are caught
+  both against shipped releases and against not-yet-released main.
+  Wired into CI as a release gate. (RUN-39195)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   pinned release and the latest published `main` chart (via
   `make e2e-upgrade-from-main` locally) — so regressions are caught
   both against shipped releases and against not-yet-released main.
-  Wired into CI as a release gate. (RUN-39195)
+  The suite is split into three idempotent stages for ad-hoc iteration:
+  `make setup-e2e-upgrade` (cluster + baseline), `make upgrade-e2e-upgrade`
+  (apply HEAD chart, re-runnable after each chart edit), and
+  `make test-e2e-upgrade` (assertions only). Wired into CI as a release
+  gate. (RUN-39195)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   device-plugin path, DRA path, multi-pool differentiation, profile
   overrides, and fake/mock coexistence. Wired into CI as a release gate.
   ([RUN-38195](https://runai.atlassian.net/browse/RUN-38195))
+- Helm-upgrade e2e suite (`make e2e-upgrade`) that installs the published
+  OCI baseline (version pinned to env-in-a-click's
+  `fake_gpu_operator_version`) and then upgrades to the chart on the
+  current branch with the same values. Catches the regression class
+  where a new top-level chart value gets referenced unsafely in a
+  template and breaks `helm upgrade` for users whose stored values
+  predate that key. Wired into CI as a release gate. (RUN-39195)
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,19 @@ teardown-e2e-mock:
 e2e-mock: setup-e2e-mock test-e2e-mock teardown-e2e-mock
 .PHONY: e2e-mock
 
+# The upgrade suite is split into three stages so the inner loop is fast:
+#   make setup-e2e-upgrade    — kind cluster + baseline OCI install   (~3 min, once)
+#   make upgrade-e2e-upgrade  — helm upgrade to local HEAD chart      (~30s,  per chart edit)
+#   make test-e2e-upgrade     — Ginkgo assertions only                (~5s,   per check)
+# Compose them via 'make e2e-upgrade' for end-to-end CI / one-shot local runs.
+
 setup-e2e-upgrade:
 	test/e2e/upgrade/scripts/setup.sh
 .PHONY: setup-e2e-upgrade
+
+upgrade-e2e-upgrade:
+	test/e2e/upgrade/scripts/apply-upgrade.sh
+.PHONY: upgrade-e2e-upgrade
 
 test-e2e-upgrade: ginkgo
 	cd test/e2e/upgrade && $(GINKGO) --procs=1 --timeout=15m --trace
@@ -84,7 +94,7 @@ teardown-e2e-upgrade:
 	test/e2e/upgrade/scripts/teardown.sh
 .PHONY: teardown-e2e-upgrade
 
-e2e-upgrade: setup-e2e-upgrade test-e2e-upgrade teardown-e2e-upgrade
+e2e-upgrade: setup-e2e-upgrade upgrade-e2e-upgrade test-e2e-upgrade teardown-e2e-upgrade
 .PHONY: e2e-upgrade
 
 # Convenience: run e2e-upgrade with the baseline pinned to the latest

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,21 @@ teardown-e2e-mock:
 e2e-mock: setup-e2e-mock test-e2e-mock teardown-e2e-mock
 .PHONY: e2e-mock
 
+setup-e2e-upgrade:
+	test/e2e/upgrade/scripts/setup.sh
+.PHONY: setup-e2e-upgrade
+
+test-e2e-upgrade: ginkgo
+	cd test/e2e/upgrade && $(GINKGO) --procs=1 --timeout=15m --trace
+.PHONY: test-e2e-upgrade
+
+teardown-e2e-upgrade:
+	test/e2e/upgrade/scripts/teardown.sh
+.PHONY: teardown-e2e-upgrade
+
+e2e-upgrade: setup-e2e-upgrade test-e2e-upgrade teardown-e2e-upgrade
+.PHONY: e2e-upgrade
+
 clean:
 	rm -rf ${BUILD_DIR}
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,24 @@ teardown-e2e-upgrade:
 e2e-upgrade: setup-e2e-upgrade test-e2e-upgrade teardown-e2e-upgrade
 .PHONY: e2e-upgrade
 
+# Convenience: run e2e-upgrade with the baseline pinned to the latest
+# pullable chart from origin/main (walks back through the last 5 commits
+# until one is found in the registry). CI does the same via matrix.
+e2e-upgrade-from-main:
+	@CHART=oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator; \
+	git fetch origin main >/dev/null 2>&1 || true; \
+	for SHA in $$(git log origin/main --format='%h' --max-count=5); do \
+		VERSION="0.0.0-$$SHA"; \
+		if helm pull $$CHART --version $$VERSION --destination /tmp >/dev/null 2>&1; then \
+			echo "Using main baseline: $$VERSION"; \
+			BASELINE_CHART_VERSION=$$VERSION $(MAKE) e2e-upgrade; \
+			exit 0; \
+		fi; \
+		echo "  not pullable: $$VERSION"; \
+	done; \
+	echo "ERROR: no chart found for the last 5 main commits"; exit 1
+.PHONY: e2e-upgrade-from-main
+
 clean:
 	rm -rf ${BUILD_DIR}
 .PHONY: clean

--- a/test/e2e/upgrade/fixtures/kind-cluster-config.yaml
+++ b/test/e2e/upgrade/fixtures/kind-cluster-config.yaml
@@ -1,0 +1,13 @@
+# KIND cluster for the helm-upgrade e2e suite.
+# Minimal config: one worker labeled for the default pool. No feature gates,
+# no CDI, no nvidia-container-toolkit setup — the upgrade flow exercises chart
+# templates and their workload pods only, not the mock NVML stack.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: upgrade-cluster
+
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      run.ai/simulated-gpu-node-pool: default-pool

--- a/test/e2e/upgrade/fixtures/values-upgrade.yaml
+++ b/test/e2e/upgrade/fixtures/values-upgrade.yaml
@@ -1,0 +1,56 @@
+# Values for the helm-upgrade e2e — deliberately mirrors what env-in-a-click
+# installs (legacy topology format: gpuProduct/gpuCount/gpuMemory, no mock
+# backend, no DRA subchart). Source of truth:
+#   https://github.com/run-ai/env-in-a-click/blob/master/thirdparty/fake_gpu_operator/helm_values.tpl
+#
+# The bug class this test catches is "new chart references a top-level key
+# that the user's stored values don't have." Using a minimalist user-realistic
+# values file is the point — a maximalist config that sets every key would
+# defeat the test.
+#
+# pullPolicy: IfNotPresent works for both phases:
+#   - install (OCI v0.0.80): images pulled from GHCR (public, no auth)
+#   - upgrade (local chart, tag=0.0.0-dev): images pre-loaded into kind by
+#     setup.sh, so IfNotPresent finds them locally without a pull attempt.
+
+devicePlugin:
+  enabled: true
+  image:
+    pullPolicy: IfNotPresent
+
+statusUpdater:
+  enabled: true
+  image:
+    pullPolicy: IfNotPresent
+
+topologyServer:
+  enabled: true
+  image:
+    pullPolicy: IfNotPresent
+
+statusExporter:
+  enabled: false
+
+migFaker:
+  enabled: false
+
+kwokGpuDevicePlugin:
+  enabled: false
+
+kwokDraPlugin:
+  enabled: false
+
+gpuOperator:
+  enabled: false
+
+nvidiaDraDriver:
+  enabled: false
+
+topology:
+  nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+  migStrategy: mixed
+  nodePools:
+    default-pool:
+      gpuProduct: NVIDIA-A100-SXM4-40GB
+      gpuCount: 4
+      gpuMemory: 40000

--- a/test/e2e/upgrade/fixtures/values-upgrade.yaml
+++ b/test/e2e/upgrade/fixtures/values-upgrade.yaml
@@ -1,15 +1,14 @@
-# Values for the helm-upgrade e2e — deliberately mirrors what env-in-a-click
-# installs (legacy topology format: gpuProduct/gpuCount/gpuMemory, no mock
-# backend, no DRA subchart). Source of truth:
-#   https://github.com/run-ai/env-in-a-click/blob/master/thirdparty/fake_gpu_operator/helm_values.tpl
+# Values for the helm-upgrade e2e — deliberately a minimal, user-realistic
+# configuration: legacy topology format (gpuProduct/gpuCount/gpuMemory), no
+# mock backend, no DRA subchart.
 #
 # The bug class this test catches is "new chart references a top-level key
-# that the user's stored values don't have." Using a minimalist user-realistic
-# values file is the point — a maximalist config that sets every key would
-# defeat the test.
+# that the user's stored values don't have." Using a minimalist values file
+# is the point — a maximalist config that sets every key would defeat the
+# test by populating keys that the new chart might be about to introduce.
 #
 # pullPolicy: IfNotPresent works for both phases:
-#   - install (OCI v0.0.80): images pulled from GHCR (public, no auth)
+#   - install (OCI baseline): images pulled from GHCR (public, no auth)
 #   - upgrade (local chart, tag=0.0.0-dev): images pre-loaded into kind by
 #     setup.sh, so IfNotPresent finds them locally without a pull attempt.
 

--- a/test/e2e/upgrade/scripts/apply-upgrade.sh
+++ b/test/e2e/upgrade/scripts/apply-upgrade.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Applies the HEAD chart on top of an already-installed baseline release.
+# Runs independently of setup.sh so an ad-hoc iteration loop can re-run it
+# after each chart edit without re-doing the cluster + baseline install.
+#
+# Captures the pre-upgrade topology ConfigMap UID into a marker file so the
+# Ginkgo suite can verify the CM was patched in place (UID unchanged), not
+# deleted+recreated, by the upgrade.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+PROJECT_ROOT="$(cd -- "${SCRIPTS_DIR}/../../../.." &> /dev/null && pwd)"
+FIXTURES_DIR="$(cd -- "${SCRIPTS_DIR}/../fixtures" &> /dev/null && pwd)"
+
+: ${KIND_CLUSTER_NAME:="upgrade-cluster"}
+: ${VALUES_FILE:="${FIXTURES_DIR}/values-upgrade.yaml"}
+: ${DOCKER_TAG:="0.0.0-dev"}
+: ${RELEASE_NAME:="fake-gpu-operator"}
+: ${RELEASE_NAMESPACE:="gpu-operator"}
+: ${MARKER_FILE:="/tmp/${KIND_CLUSTER_NAME}-pre-upgrade-cm-uid"}
+
+if ! kind get clusters | grep -q "^${KIND_CLUSTER_NAME}$"; then
+    echo "ERROR: cluster ${KIND_CLUSTER_NAME} not found. Run 'make setup-e2e-upgrade' first."
+    exit 1
+fi
+kubectl config use-context "kind-${KIND_CLUSTER_NAME}" >/dev/null
+
+echo "==> Capturing pre-upgrade topology ConfigMap UID..."
+PRE_UID=$(kubectl get cm -n "${RELEASE_NAMESPACE}" topology -o jsonpath='{.metadata.uid}')
+if [[ -z "${PRE_UID}" ]]; then
+    echo "ERROR: topology ConfigMap not found in ${RELEASE_NAMESPACE} — has the baseline been installed?"
+    exit 1
+fi
+echo "${PRE_UID}" > "${MARKER_FILE}"
+echo "    pre-upgrade UID: ${PRE_UID}"
+echo "    marker file:     ${MARKER_FILE}"
+
+echo "==> Resolving subchart deps for the local chart..."
+cd "${PROJECT_ROOT}"
+helm dependency update deploy/fake-gpu-operator
+
+echo "==> Upgrading ${RELEASE_NAME} to the local HEAD chart (tag ${DOCKER_TAG})..."
+helm upgrade "${RELEASE_NAME}" deploy/fake-gpu-operator \
+    --namespace "${RELEASE_NAMESPACE}" \
+    -f "${VALUES_FILE}" \
+    --set devicePlugin.image.tag="${DOCKER_TAG}" \
+    --set statusUpdater.image.tag="${DOCKER_TAG}" \
+    --set topologyServer.image.tag="${DOCKER_TAG}" \
+    --wait --timeout 5m
+
+echo ""
+echo "===================================================="
+echo "Upgrade applied. Run 'make test-e2e-upgrade' to verify."
+echo "===================================================="

--- a/test/e2e/upgrade/scripts/setup.sh
+++ b/test/e2e/upgrade/scripts/setup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Brings up a KIND cluster, builds + loads local component images for the
+# eventual upgrade step, then installs the published OCI baseline release.
+# The Ginkgo suite then runs `helm upgrade` against the local chart and
+# asserts the upgrade succeeds — exercising the class of bug where a new
+# top-level chart value is referenced unsafely in a template (RUN-39195).
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+PROJECT_ROOT="$(cd -- "${SCRIPTS_DIR}/../../../.." &> /dev/null && pwd)"
+FIXTURES_DIR="$(cd -- "${SCRIPTS_DIR}/../fixtures" &> /dev/null && pwd)"
+
+CURRENT_PLATFORM="linux/$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
+
+# Baseline chart version. Pinned to the version env-in-a-click currently
+# installs in real environments — see:
+#   https://github.com/run-ai/env-in-a-click/blob/master/thirdparty/variables.tf
+# Bump in lockstep with env-in-a-click's `fake_gpu_operator_version` default.
+: ${BASELINE_CHART_VERSION:="0.0.80"}
+
+: ${KIND_CLUSTER_NAME:="upgrade-cluster"}
+: ${VALUES_FILE:="${FIXTURES_DIR}/values-upgrade.yaml"}
+: ${KIND_CLUSTER_CONFIG_PATH:="${FIXTURES_DIR}/kind-cluster-config.yaml"}
+: ${KIND_K8S_TAG:="v1.34.2"}
+: ${KIND_IMAGE:="kindest/node:${KIND_K8S_TAG}"}
+: ${DOCKER_TAG:="0.0.0-dev"}
+: ${DOCKER_REPO_BASE:="ghcr.io/run-ai/fake-gpu-operator"}
+: ${BASELINE_CHART_REF:="oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator"}
+: ${RELEASE_NAME:="fake-gpu-operator"}
+: ${RELEASE_NAMESPACE:="gpu-operator"}
+
+if ! command -v docker &> /dev/null; then
+    echo "Docker not found. Please install Docker."
+    exit 1
+fi
+
+if [[ "${SKIP_SETUP:-false}" == "true" ]]; then
+    echo "Skipping setup (SKIP_SETUP=true)"
+    exit 0
+fi
+
+if kind get clusters | grep -q "^${KIND_CLUSTER_NAME}$"; then
+    echo "Cluster ${KIND_CLUSTER_NAME} already exists. Use SKIP_SETUP=true or delete the cluster first."
+    exit 1
+fi
+
+echo "==> Building local Docker images (platform ${CURRENT_PLATFORM}, tag ${DOCKER_TAG})..."
+# Built once here so the eventual `helm upgrade` (run by the Ginkgo suite)
+# finds the local images already loaded into kind.
+cd "${PROJECT_ROOT}"
+make image DOCKER_TAG="${DOCKER_TAG}" DOCKER_BUILDX_PLATFORMS="${CURRENT_PLATFORM}" DOCKER_BUILDX_PUSH_FLAG="--load"
+
+echo "==> Creating kind cluster ${KIND_CLUSTER_NAME}..."
+kind create cluster \
+    --name "${KIND_CLUSTER_NAME}" \
+    --image "${KIND_IMAGE}" \
+    --config "${KIND_CLUSTER_CONFIG_PATH}" \
+    --wait 2m
+
+echo "==> Loading local FGO images into kind..."
+# Only the components enabled by values-upgrade.yaml — devicePlugin,
+# statusUpdater, topologyServer. Loading the rest wastes time.
+for component in device-plugin status-updater topology-server; do
+    IMAGE="${DOCKER_REPO_BASE}/${component}:${DOCKER_TAG}"
+    echo "    -- ${IMAGE}"
+    kind load docker-image --name "${KIND_CLUSTER_NAME}" "${IMAGE}"
+done
+
+echo "==> Installing baseline chart ${BASELINE_CHART_REF} version ${BASELINE_CHART_VERSION}..."
+# pullPolicy: IfNotPresent in values-upgrade.yaml; baseline pulls from GHCR
+# (public, no auth needed), local upgrade later reuses kind-loaded images.
+helm install "${RELEASE_NAME}" "${BASELINE_CHART_REF}" \
+    --version "${BASELINE_CHART_VERSION}" \
+    --namespace "${RELEASE_NAMESPACE}" \
+    --create-namespace \
+    -f "${VALUES_FILE}" \
+    --wait --timeout 5m
+
+echo "==> Baseline release info:"
+helm list --namespace "${RELEASE_NAMESPACE}"
+
+echo ""
+echo "===================================================="
+echo "Setup complete!"
+echo "  Cluster: ${KIND_CLUSTER_NAME}"
+echo "  Baseline: ${RELEASE_NAME} @ ${BASELINE_CHART_VERSION}"
+echo "  Local images loaded for upgrade step (tag: ${DOCKER_TAG})"
+echo "===================================================="

--- a/test/e2e/upgrade/scripts/setup.sh
+++ b/test/e2e/upgrade/scripts/setup.sh
@@ -14,10 +14,9 @@ FIXTURES_DIR="$(cd -- "${SCRIPTS_DIR}/../fixtures" &> /dev/null && pwd)"
 
 CURRENT_PLATFORM="linux/$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
 
-# Baseline chart version. Pinned to the version env-in-a-click currently
-# installs in real environments — see:
-#   https://github.com/run-ai/env-in-a-click/blob/master/thirdparty/variables.tf
-# Bump in lockstep with env-in-a-click's `fake_gpu_operator_version` default.
+# Baseline chart version. Pinned to a known-good published release so the
+# upgrade path is deterministic and reproducible — bumping this is an
+# intentional change, not a side-effect of "newest available on GHCR".
 : ${BASELINE_CHART_VERSION:="0.0.80"}
 
 : ${KIND_CLUSTER_NAME:="upgrade-cluster"}

--- a/test/e2e/upgrade/scripts/teardown.sh
+++ b/test/e2e/upgrade/scripts/teardown.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+: ${KIND_CLUSTER_NAME:="upgrade-cluster"}
+
+if ! command -v docker &> /dev/null; then
+    echo "Docker not found. Please install Docker."
+    exit 1
+fi
+
+if [[ "${SKIP_TEARDOWN:-false}" == "true" ]]; then
+    echo "Skipping teardown (SKIP_TEARDOWN=true)"
+    exit 0
+fi
+
+echo "Deleting kind cluster ${KIND_CLUSTER_NAME}..."
+kind delete cluster --name "${KIND_CLUSTER_NAME}"
+
+echo "Teardown complete!"

--- a/test/e2e/upgrade/upgrade_suite_test.go
+++ b/test/e2e/upgrade/upgrade_suite_test.go
@@ -18,24 +18,18 @@ import (
 )
 
 const (
-	releaseName      = "fake-gpu-operator"
 	releaseNamespace = "gpu-operator"
 
 	// Synonym of the singular ConfigMap created by templates/topology-cm.yml.
 	// Its preservation across helm upgrade is the canary for this suite.
 	topologyCMName = "topology"
 
-	helmUpgradeTimeout = 5 * time.Minute
-	podReadyTimeout    = 3 * time.Minute
+	podReadyTimeout = 3 * time.Minute
 )
 
 var (
 	kubeClient kubernetes.Interface
 	restConfig *rest.Config
-
-	// projectRoot is repo root, resolved at suite-bootstrap so test code can
-	// reference the local chart path without depending on cwd.
-	projectRoot string
 )
 
 func TestUpgrade(t *testing.T) {
@@ -52,12 +46,11 @@ var _ = BeforeSuite(func() {
 	kubeClient, err = kubernetes.NewForConfig(restConfig)
 	Expect(err).NotTo(HaveOccurred())
 
-	projectRoot, err = resolveProjectRoot()
-	Expect(err).NotTo(HaveOccurred())
-
-	// Sanity: baseline release was installed by setup.sh.
+	// Sanity: cluster reachable and the release namespace exists (the
+	// baseline install creates it).
 	_, err = kubeClient.CoreV1().Namespaces().Get(context.Background(), releaseNamespace, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred(), "namespace %s must exist (setup.sh helm install)", releaseNamespace)
+	Expect(err).NotTo(HaveOccurred(),
+		"namespace %s must exist (setup.sh helm install)", releaseNamespace)
 })
 
 func getKubeConfig() (*rest.Config, error) {
@@ -74,25 +67,4 @@ func getKubeConfig() (*rest.Config, error) {
 		return nil, fmt.Errorf("loading kubeconfig from %q: %w", kubeconfig, err)
 	}
 	return cfg, nil
-}
-
-// resolveProjectRoot walks up from this test file's directory until it finds
-// the repo's Makefile, so test code can build paths to the local chart
-// regardless of where the test binary was invoked.
-func resolveProjectRoot() (string, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	dir := wd
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "Makefile")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("could not find Makefile from %s upward", wd)
-		}
-		dir = parent
-	}
 }

--- a/test/e2e/upgrade/upgrade_suite_test.go
+++ b/test/e2e/upgrade/upgrade_suite_test.go
@@ -1,0 +1,98 @@
+package upgrade_e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	releaseName      = "fake-gpu-operator"
+	releaseNamespace = "gpu-operator"
+
+	// Synonym of the singular ConfigMap created by templates/topology-cm.yml.
+	// Its preservation across helm upgrade is the canary for this suite.
+	topologyCMName = "topology"
+
+	helmUpgradeTimeout = 5 * time.Minute
+	podReadyTimeout    = 3 * time.Minute
+)
+
+var (
+	kubeClient kubernetes.Interface
+	restConfig *rest.Config
+
+	// projectRoot is repo root, resolved at suite-bootstrap so test code can
+	// reference the local chart path without depending on cwd.
+	projectRoot string
+)
+
+func TestUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helm Upgrade E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	restConfig, err = getKubeConfig()
+	Expect(err).NotTo(HaveOccurred())
+
+	kubeClient, err = kubernetes.NewForConfig(restConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	projectRoot, err = resolveProjectRoot()
+	Expect(err).NotTo(HaveOccurred())
+
+	// Sanity: baseline release was installed by setup.sh.
+	_, err = kubeClient.CoreV1().Namespaces().Get(context.Background(), releaseNamespace, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "namespace %s must exist (setup.sh helm install)", releaseNamespace)
+})
+
+func getKubeConfig() (*rest.Config, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		kubeconfig = filepath.Join(home, ".kube", "config")
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("loading kubeconfig from %q: %w", kubeconfig, err)
+	}
+	return cfg, nil
+}
+
+// resolveProjectRoot walks up from this test file's directory until it finds
+// the repo's Makefile, so test code can build paths to the local chart
+// regardless of where the test binary was invoked.
+func resolveProjectRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "Makefile")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find Makefile from %s upward", wd)
+		}
+		dir = parent
+	}
+}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -21,8 +21,8 @@ var _ = Describe("Helm upgrade from baseline OCI release to local chart", func()
 
 	BeforeEach(func() {
 		// Capture pre-upgrade UID of the topology CM. After upgrade, an
-		// unchanged UID proves the CM was preserved (not deleted+recreated),
-		// which is what users on env-in-a-click would see.
+		// unchanged UID proves the CM was preserved (not deleted+recreated)
+		// — preserving it across upgrade is what real users expect.
 		cm, err := kubeClient.CoreV1().ConfigMaps(releaseNamespace).Get(
 			context.Background(), topologyCMName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(),

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -1,0 +1,140 @@
+package upgrade_e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Helm upgrade from baseline OCI release to local chart", func() {
+	var preUpgradeTopologyUID types.UID
+
+	BeforeEach(func() {
+		// Capture pre-upgrade UID of the topology CM. After upgrade, an
+		// unchanged UID proves the CM was preserved (not deleted+recreated),
+		// which is what users on env-in-a-click would see.
+		cm, err := kubeClient.CoreV1().ConfigMaps(releaseNamespace).Get(
+			context.Background(), topologyCMName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(),
+			"baseline release must have created the %q ConfigMap", topologyCMName)
+		preUpgradeTopologyUID = cm.UID
+	})
+
+	It("upgrades cleanly to the local chart with the same values", func() {
+		localChartPath := filepath.Join(projectRoot, "deploy", "fake-gpu-operator")
+		valuesPath := filepath.Join(projectRoot, "test", "e2e", "upgrade", "fixtures", "values-upgrade.yaml")
+		dockerTag := "0.0.0-dev"
+
+		// `helm dependency update` populates charts/ for the conditional
+		// subcharts (gpuOperator / nvidiaDraDriver). Even though they render
+		// to nothing here, helm refuses to upgrade with missing dep archives.
+		runOrFail("helm", "dependency", "update", localChartPath)
+
+		// The upgrade. If any template references a top-level value that
+		// the baseline's stored values lack, this fails — which is the
+		// regression class RUN-39195 exists to catch.
+		runOrFail("helm", "upgrade", releaseName, localChartPath,
+			"--namespace", releaseNamespace,
+			"-f", valuesPath,
+			"--set", "devicePlugin.image.tag="+dockerTag,
+			"--set", "statusUpdater.image.tag="+dockerTag,
+			"--set", "topologyServer.image.tag="+dockerTag,
+			"--wait", "--timeout", helmUpgradeTimeout.String(),
+		)
+
+		By("verifying enabled component pods reach steady state")
+		waitForPodReady("app=status-updater", podReadyTimeout)
+		waitForPodReady("app=topology-server", podReadyTimeout)
+		// status-updater labels worker nodes with
+		// `nvidia.com/gpu.deploy.device-plugin=true` after start-up
+		// (see internal/status-updater/handlers/node/labels.go). The
+		// device-plugin DaemonSet selects on that label, so its pod count
+		// goes from 0 to 1 a few seconds after status-updater is Ready.
+		waitForDaemonSetReady("device-plugin", podReadyTimeout)
+
+		By("verifying the topology ConfigMap was preserved across upgrade")
+		postCM, err := kubeClient.CoreV1().ConfigMaps(releaseNamespace).Get(
+			context.Background(), topologyCMName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(postCM.UID).To(Equal(preUpgradeTopologyUID),
+			"topology ConfigMap should be patched in place, not recreated")
+		Expect(postCM.Data).To(HaveKey("topology.yml"))
+
+		By("verifying helm sees the release as deployed (not failed/pending)")
+		out := runOrFail("helm", "list", "--namespace", releaseNamespace, "-o", "json")
+		Expect(out).To(ContainSubstring(`"status":"deployed"`),
+			"helm release should be in 'deployed' state after upgrade")
+	})
+})
+
+// runOrFail shells out to a command, streams output to GinkgoWriter, and
+// fails the spec with the captured output if the command exits non-zero.
+func runOrFail(name string, args ...string) string {
+	GinkgoWriter.Printf("$ %s %s\n", name, strings.Join(args, " "))
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	GinkgoWriter.Print(string(out))
+	Expect(err).NotTo(HaveOccurred(),
+		"command failed: %s %s\n--- output ---\n%s", name, strings.Join(args, " "), string(out))
+	return string(out)
+}
+
+// waitForPodReady polls until every pod matching the label selector in
+// releaseNamespace is Running + Ready (mirrors mock suite helper).
+func waitForPodReady(labelSelector string, timeout time.Duration) {
+	Eventually(func() error {
+		pods, err := kubeClient.CoreV1().Pods(releaseNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return err
+		}
+		if len(pods.Items) == 0 {
+			return fmt.Errorf("no pods match selector %q", labelSelector)
+		}
+		for _, p := range pods.Items {
+			if p.Status.Phase != corev1.PodRunning {
+				return fmt.Errorf("pod %s phase %s (want Running)", p.Name, p.Status.Phase)
+			}
+			ready := false
+			for _, c := range p.Status.Conditions {
+				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+					ready = true
+					break
+				}
+			}
+			if !ready {
+				return fmt.Errorf("pod %s not Ready", p.Name)
+			}
+		}
+		return nil
+	}, timeout, 2*time.Second).Should(Succeed(), "no Ready pods for selector %q", labelSelector)
+}
+
+// waitForDaemonSetReady polls until the named DaemonSet reports
+// numberReady == desiredNumberScheduled (and desired > 0).
+func waitForDaemonSetReady(name string, timeout time.Duration) {
+	Eventually(func() error {
+		ds, err := kubeClient.AppsV1().DaemonSets(releaseNamespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if ds.Status.DesiredNumberScheduled == 0 {
+			return fmt.Errorf("DaemonSet %s desiredNumberScheduled=0 (no matching nodes?)", name)
+		}
+		if ds.Status.NumberReady != ds.Status.DesiredNumberScheduled {
+			return fmt.Errorf("DaemonSet %s: %d/%d ready", name, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled)
+		}
+		return nil
+	}, timeout, 2*time.Second).Should(Succeed())
+}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -35,22 +35,18 @@ var _ = Describe("Helm upgrade from baseline OCI release to local chart", func()
 		valuesPath := filepath.Join(projectRoot, "test", "e2e", "upgrade", "fixtures", "values-upgrade.yaml")
 		dockerTag := "0.0.0-dev"
 
-		// `helm dependency update` populates charts/ for the conditional
-		// subcharts (gpuOperator / nvidiaDraDriver). Even though they render
-		// to nothing here, helm refuses to upgrade with missing dep archives.
-		runOrFail("helm", "dependency", "update", localChartPath)
+		// Populate charts/ for the conditional subcharts (gpuOperator /
+		// nvidiaDraDriver). Even though they render to nothing here, helm
+		// refuses to upgrade with missing dep archives.
+		helm("dependency", "update", localChartPath)
 
 		// The upgrade. If any template references a top-level value that
 		// the baseline's stored values lack, this fails — which is the
 		// regression class RUN-39195 exists to catch.
-		runOrFail("helm", "upgrade", releaseName, localChartPath,
-			"--namespace", releaseNamespace,
-			"-f", valuesPath,
-			"--set", "devicePlugin.image.tag="+dockerTag,
-			"--set", "statusUpdater.image.tag="+dockerTag,
-			"--set", "topologyServer.image.tag="+dockerTag,
-			"--wait", "--timeout", helmUpgradeTimeout.String(),
-		)
+		upgradeArgs := []string{"upgrade", releaseName, localChartPath, "-f", valuesPath}
+		upgradeArgs = append(upgradeArgs, imageTagSets(dockerTag, "devicePlugin", "statusUpdater", "topologyServer")...)
+		upgradeArgs = append(upgradeArgs, "--wait", "--timeout", helmUpgradeTimeout.String())
+		helm(upgradeArgs...)
 
 		By("verifying enabled component pods reach steady state")
 		waitForPodReady("app=status-updater", podReadyTimeout)
@@ -71,11 +67,30 @@ var _ = Describe("Helm upgrade from baseline OCI release to local chart", func()
 		Expect(postCM.Data).To(HaveKey("topology.yml"))
 
 		By("verifying helm sees the release as deployed (not failed/pending)")
-		out := runOrFail("helm", "list", "--namespace", releaseNamespace, "-o", "json")
+		out := helm("list", "-o", "json")
 		Expect(out).To(ContainSubstring(`"status":"deployed"`),
 			"helm release should be in 'deployed' state after upgrade")
 	})
 })
+
+// helm runs `helm <args...>` with -n releaseNamespace pre-populated. The
+// namespace flag is a helm global, accepted (and ignored) by subcommands
+// like `dependency update` that don't operate on a cluster — so bundling
+// it here keeps every call site one short slice.
+func helm(args ...string) string {
+	return runOrFail("helm", append([]string{"-n", releaseNamespace}, args...)...)
+}
+
+// imageTagSets returns the `--set <component>.image.tag=<tag>` pairs that
+// flip every named chart component from the baseline's published tag to the
+// local-build tag for the upgrade step.
+func imageTagSets(tag string, components ...string) []string {
+	out := make([]string, 0, 2*len(components))
+	for _, c := range components {
+		out = append(out, "--set", c+".image.tag="+tag)
+	}
+	return out
+}
 
 // runOrFail shells out to a command, streams output to GinkgoWriter, and
 // fails the spec with the captured output if the command exits non-zero.

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -3,8 +3,8 @@ package upgrade_e2e_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -16,37 +16,19 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// markerFile is where scripts/apply-upgrade.sh writes the pre-upgrade
+// topology ConfigMap UID. The Ginkgo suite reads it to verify the CM was
+// patched in place (UID unchanged), not deleted+recreated, by the upgrade.
+const markerFile = "/tmp/upgrade-cluster-pre-upgrade-cm-uid"
+
 var _ = Describe("Helm upgrade from baseline OCI release to local chart", func() {
-	var preUpgradeTopologyUID types.UID
-
-	BeforeEach(func() {
-		// Capture pre-upgrade UID of the topology CM. After upgrade, an
-		// unchanged UID proves the CM was preserved (not deleted+recreated)
-		// — preserving it across upgrade is what real users expect.
-		cm, err := kubeClient.CoreV1().ConfigMaps(releaseNamespace).Get(
-			context.Background(), topologyCMName, metav1.GetOptions{})
+	It("leaves the release healthy and the topology ConfigMap preserved", func() {
+		By("reading pre-upgrade CM UID written by apply-upgrade.sh")
+		raw, err := os.ReadFile(markerFile)
 		Expect(err).NotTo(HaveOccurred(),
-			"baseline release must have created the %q ConfigMap", topologyCMName)
-		preUpgradeTopologyUID = cm.UID
-	})
-
-	It("upgrades cleanly to the local chart with the same values", func() {
-		localChartPath := filepath.Join(projectRoot, "deploy", "fake-gpu-operator")
-		valuesPath := filepath.Join(projectRoot, "test", "e2e", "upgrade", "fixtures", "values-upgrade.yaml")
-		dockerTag := "0.0.0-dev"
-
-		// Populate charts/ for the conditional subcharts (gpuOperator /
-		// nvidiaDraDriver). Even though they render to nothing here, helm
-		// refuses to upgrade with missing dep archives.
-		helm("dependency", "update", localChartPath)
-
-		// The upgrade. If any template references a top-level value that
-		// the baseline's stored values lack, this fails — which is the
-		// regression class RUN-39195 exists to catch.
-		upgradeArgs := []string{"upgrade", releaseName, localChartPath, "-f", valuesPath}
-		upgradeArgs = append(upgradeArgs, imageTagSets(dockerTag, "devicePlugin", "statusUpdater", "topologyServer")...)
-		upgradeArgs = append(upgradeArgs, "--wait", "--timeout", helmUpgradeTimeout.String())
-		helm(upgradeArgs...)
+			"marker file %s missing — has apply-upgrade.sh run?", markerFile)
+		preUpgradeUID := types.UID(strings.TrimSpace(string(raw)))
+		Expect(preUpgradeUID).NotTo(BeEmpty(), "marker file should contain a UID")
 
 		By("verifying enabled component pods reach steady state")
 		waitForPodReady("app=status-updater", podReadyTimeout)
@@ -62,35 +44,16 @@ var _ = Describe("Helm upgrade from baseline OCI release to local chart", func()
 		postCM, err := kubeClient.CoreV1().ConfigMaps(releaseNamespace).Get(
 			context.Background(), topologyCMName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(postCM.UID).To(Equal(preUpgradeTopologyUID),
+		Expect(postCM.UID).To(Equal(preUpgradeUID),
 			"topology ConfigMap should be patched in place, not recreated")
 		Expect(postCM.Data).To(HaveKey("topology.yml"))
 
 		By("verifying helm sees the release as deployed (not failed/pending)")
-		out := helm("list", "-o", "json")
+		out := runOrFail("helm", "-n", releaseNamespace, "list", "-o", "json")
 		Expect(out).To(ContainSubstring(`"status":"deployed"`),
 			"helm release should be in 'deployed' state after upgrade")
 	})
 })
-
-// helm runs `helm <args...>` with -n releaseNamespace pre-populated. The
-// namespace flag is a helm global, accepted (and ignored) by subcommands
-// like `dependency update` that don't operate on a cluster — so bundling
-// it here keeps every call site one short slice.
-func helm(args ...string) string {
-	return runOrFail("helm", append([]string{"-n", releaseNamespace}, args...)...)
-}
-
-// imageTagSets returns the `--set <component>.image.tag=<tag>` pairs that
-// flip every named chart component from the baseline's published tag to the
-// local-build tag for the upgrade step.
-func imageTagSets(tag string, components ...string) []string {
-	out := make([]string, 0, 2*len(components))
-	for _, c := range components {
-		out = append(out, "--set", c+".image.tag="+tag)
-	}
-	return out
-}
 
 // runOrFail shells out to a command, streams output to GinkgoWriter, and
 // fails the spec with the captured output if the command exits non-zero.


### PR DESCRIPTION
## Summary

- Adds `make e2e-upgrade` — a KIND-based e2e that installs a pinned published OCI baseline chart, then `helm upgrade`s to the chart on this branch and asserts the release stays healthy + topology ConfigMap is preserved.
- Baseline pinned to `0.0.80`. Bumping is intentional, not automatic — the deterministic baseline makes regressions reproducible.
- Catches the class of bug where a new top-level chart value gets referenced unsafely in a template and breaks `helm upgrade` for users whose stored values predate that key — see commit `ef15cf8` (PR #193) for the `(.Values.X).Y` nil-safe fix pattern.
- Wired into CI as a release gate (`release-docker` now `needs: e2e-upgrade`); runs on every PR via the existing `pull_request: branches: [main]` trigger.

## Implementation notes

- Separate KIND cluster (`upgrade-cluster`) — isolated from `mock-cluster` used by `e2e-mock`.
- Values file (`test/e2e/upgrade/fixtures/values-upgrade.yaml`) is deliberately minimal and user-realistic: legacy `gpuProduct`/`gpuCount`/`gpuMemory` topology, no mock backend, no DRA subchart, `pullPolicy: IfNotPresent`. A maximalist values file would defeat the test by populating keys the new chart might be about to introduce.
- Setup builds + `kind load`s local images once, so the eventual `helm upgrade` to the local chart finds them cached.
- Assertions: helm upgrade exits 0, enabled component pods (status-updater, topology-server, device-plugin DS) reach steady state, topology ConfigMap UID unchanged (proves CM was patched in place, not recreated), helm release status is `deployed`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./test/e2e/upgrade/...`
- [x] `bash -n` on `setup.sh` / `teardown.sh`
- [x] `make e2e-upgrade` end-to-end locally — install 0.0.80, upgrade to local chart, assertions pass (1/1 specs, ~60s after setup)
- [ ] CI `e2e-upgrade` job green on this PR