### PR TITLE
docs(changelog): release v0.0.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+
+## [0.0.81] - 2026-05-27
+
+### Added
+
 - `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and structured issue
   templates (`BUG_REPORT.yaml`, `ENHANCEMENT.yaml`) to guide external
   contributors. ([RUN-38925](https://runai.atlassian.net/browse/RUN-38925))


### PR DESCRIPTION
## Summary

Promotes the current `[Unreleased]` section into a new `[0.0.81] - 2026-05-27` section, leaving an empty `[Unreleased]` scaffold for the next cycle.

This PR is **release preparation only** — no code changes, just `CHANGELOG.md`. After this merges, the actual release is cut by tagging the resulting main commit:

```bash
git checkout main && git pull
git tag v0.0.81
git push origin v0.0.81
```

The tag push triggers `release-docker` (builds all 11 component images at `:0.0.81`, multi-arch) and `release-helm` (packages + pushes the chart at `oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator:0.0.81`).

## What's in v0.0.81

Aggregates merged work since v0.0.80 (released 2026-04-12):

- **RUN-38195** — Mock backend (`gpu.backend: mock`) with profile-driven nvml-mock DaemonSet, gpu-operator + nvidia-dra-driver-gpu subchart wiring, KIND-based mock-pool e2e suite, plus follow-up fixes (RBAC `watch` verb on configmaps, toolkit-ready marker write so operand DaemonSets unblock).
- **RUN-38925** — `CONTRIBUTING.md`, PR/issue templates, `CHANGELOG.md`.
- **RUN-39005** — `kwok-dra-plugin` ResourceSlice + DeviceClass aligned with upstream `nvidia-dra-driver-gpu`'s CEL selector (qualified `gpu.nvidia.com/{type,uuid,productName}` attributes).
- **RUN-39195** — Helm-upgrade regression e2e suite (`make e2e-upgrade`), two-baseline matrix (pinned + latest-main), split into three idempotent stages for ad-hoc iteration.

## Test plan

- [x] `CHANGELOG.md` renders correctly — Unreleased empty scaffold + new 0.0.81 section dated 2026-05-27
- [x] Branched off `origin/main` so the diff is *only* the CHANGELOG promotion
- [ ] Merge to main, then tag `v0.0.81` to publish the release