### PR TITLE
fix(device-plugin): inject NODE_NAME so nvidia-smi resolves node topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- E2E coverage for the legacy device-plugin path in `make e2e`: enables
-  `devicePlugin` and adds a spec that runs `/bin/nvidia-smi` in a non-DRA
-  `nvidia.com/gpu` pod, guarding against the regression below.
-  ([#191](https://github.com/run-ai/fake-gpu-operator/issues/191), RUN-39004)
-
 ### Changed
 
 ### Fixed
 
-- `device-plugin` `Allocate()` now injects `NODE_NAME` into workload
-  containers, reaching parity with the DRA/CDI path. Without it, a non-DRA pod
-  running `/bin/nvidia-smi` queried an empty node on `topology-server` and
-  panicked decoding the plain-text error response
-  (`invalid character 'C'`). `nvidia-smi` also now fails with a clear message
-  on non-2xx topology responses instead of a JSON-decode panic.
-  ([#191](https://github.com/run-ai/fake-gpu-operator/issues/191), RUN-39004)
+- `device-plugin` injects `NODE_NAME` so non-DRA pods can run the fake `nvidia-smi`. ([#191](https://github.com/run-ai/fake-gpu-operator/issues/191))
 
 
 ## [0.0.81] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- E2E coverage for the legacy device-plugin path in `make e2e`: enables
+  `devicePlugin` and adds a spec that runs `/bin/nvidia-smi` in a non-DRA
+  `nvidia.com/gpu` pod, guarding against the regression below.
+  ([#191](https://github.com/run-ai/fake-gpu-operator/issues/191), RUN-39004)
+
 ### Changed
 
 ### Fixed
+
+- `device-plugin` `Allocate()` now injects `NODE_NAME` into workload
+  containers, reaching parity with the DRA/CDI path. Without it, a non-DRA pod
+  running `/bin/nvidia-smi` queried an empty node on `topology-server` and
+  panicked decoding the plain-text error response
+  (`invalid character 'C'`). `nvidia-smi` also now fails with a clear message
+  on non-2xx topology responses instead of a JSON-decode panic.
+  ([#191](https://github.com/run-ai/fake-gpu-operator/issues/191), RUN-39004)
 
 
 ## [0.0.81] - 2026-05-27

--- a/README.md
+++ b/README.md
@@ -68,11 +68,6 @@ spec:
     resources:
       limits:
         nvidia.com/gpu: 1
-    env:
-      - name: NODE_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
 ```
 
 ## 🛠️ Configuration
@@ -408,15 +403,10 @@ kubectl label ns gpu-operator pod-security.kubernetes.io/enforce=privileged
 
 ### nvidia-smi Support
 
-The operator injects a simulated `nvidia-smi` tool into GPU pods. Ensure your pods include the required environment variable:
-
-```yaml
-env:
-  - name: NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-```
+The operator injects a simulated `nvidia-smi` tool into GPU pods. `nvidia-smi` uses the
+`NODE_NAME` environment variable to resolve the pod's node topology; both the device-plugin
+and the DRA driver inject it automatically at allocation time, so no manual pod configuration
+is required.
 
 ## 🤝 Contributing
 

--- a/cmd/nvidia-smi/main.go
+++ b/cmd/nvidia-smi/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -71,6 +72,19 @@ func getNvidiaSmiArgs() []nvidiaSmiArgs {
 	resp, err := http.Get(topologyUrl)
 	if err != nil {
 		panic(err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Error closing response body: %v\n", err)
+		}
+	}()
+
+	// Guard against non-JSON responses (e.g. an empty NODE_NAME yields a plain-text
+	// error from topology-server) so we fail with a clear message instead of a
+	// cryptic JSON decode panic.
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		panic(fmt.Sprintf("topology-server returned %d for %s: %s", resp.StatusCode, topologyUrl, strings.TrimSpace(string(body))))
 	}
 
 	var nodeTopology topology.NodeTopology

--- a/cmd/nvidia-smi/main.go
+++ b/cmd/nvidia-smi/main.go
@@ -79,9 +79,6 @@ func getNvidiaSmiArgs() []nvidiaSmiArgs {
 		}
 	}()
 
-	// Guard against non-JSON responses (e.g. an empty NODE_NAME yields a plain-text
-	// error from topology-server) so we fail with a clear message instead of a
-	// cryptic JSON decode panic.
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		panic(fmt.Sprintf("topology-server returned %d for %s: %s", resp.StatusCode, topologyUrl, strings.TrimSpace(string(body))))

--- a/cmd/nvidia-smi/main.go
+++ b/cmd/nvidia-smi/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -72,16 +71,6 @@ func getNvidiaSmiArgs() []nvidiaSmiArgs {
 	resp, err := http.Get(topologyUrl)
 	if err != nil {
 		panic(err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("Error closing response body: %v\n", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		panic(fmt.Sprintf("topology-server returned %d for %s: %s", resp.StatusCode, topologyUrl, strings.TrimSpace(string(body))))
 	}
 
 	var nodeTopology topology.NodeTopology

--- a/internal/deviceplugin/real_node.go
+++ b/internal/deviceplugin/real_node.go
@@ -178,10 +178,8 @@ func (m *RealNodeDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.All
 		response := pluginapi.ContainerAllocateResponse{
 			Envs: map[string]string{
 				"MOCK_NVIDIA_VISIBLE_DEVICES": strings.Join(req.DevicesIds, ","),
-				// nvidia-smi resolves its node topology from NODE_NAME. The
-				// DaemonSet receives it via the downward API (spec.nodeName);
-				// propagate it to the workload so /bin/nvidia-smi doesn't query
-				// an empty node and panic on the non-JSON error response.
+				// Propagate NODE_NAME (from the DaemonSet's downward API) so the workload's
+				// nvidia-smi can resolve its node topology.
 				constants.EnvNodeName: os.Getenv(constants.EnvNodeName),
 			},
 			Mounts: []*pluginapi.Mount{

--- a/internal/deviceplugin/real_node.go
+++ b/internal/deviceplugin/real_node.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/run-ai/fake-gpu-operator/internal/common/constants"
 	"github.com/run-ai/fake-gpu-operator/internal/common/topology"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -177,6 +178,11 @@ func (m *RealNodeDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.All
 		response := pluginapi.ContainerAllocateResponse{
 			Envs: map[string]string{
 				"MOCK_NVIDIA_VISIBLE_DEVICES": strings.Join(req.DevicesIds, ","),
+				// nvidia-smi resolves its node topology from NODE_NAME. The
+				// DaemonSet receives it via the downward API (spec.nodeName);
+				// propagate it to the workload so /bin/nvidia-smi doesn't query
+				// an empty node and panic on the non-JSON error response.
+				constants.EnvNodeName: os.Getenv(constants.EnvNodeName),
 			},
 			Mounts: []*pluginapi.Mount{
 				{

--- a/internal/deviceplugin/real_node_test.go
+++ b/internal/deviceplugin/real_node_test.go
@@ -1,0 +1,44 @@
+package deviceplugin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/run-ai/fake-gpu-operator/internal/common/constants"
+)
+
+var _ = Describe("RealNodeDevicePlugin Allocate", func() {
+	const nodeName = "worker-1"
+
+	BeforeEach(func() {
+		GinkgoT().Setenv(constants.EnvNodeName, nodeName)
+	})
+
+	It("injects NODE_NAME, MOCK_NVIDIA_VISIBLE_DEVICES and the nvidia-smi mount", func() {
+		m := &RealNodeDevicePlugin{}
+		reqs := &pluginapi.AllocateRequest{
+			ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+				{DevicesIds: []string{"gpu-0", "gpu-1"}},
+			},
+		}
+
+		resp, err := m.Allocate(context.Background(), reqs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.ContainerResponses).To(HaveLen(1))
+
+		container := resp.ContainerResponses[0]
+		// The actual fix for RUN-39004: NODE_NAME must be propagated so nvidia-smi
+		// can resolve its node topology instead of querying an empty node.
+		Expect(container.Envs).To(HaveKeyWithValue(constants.EnvNodeName, nodeName))
+		// Pre-existing behavior must be preserved.
+		Expect(container.Envs).To(HaveKeyWithValue("MOCK_NVIDIA_VISIBLE_DEVICES", "gpu-0,gpu-1"))
+		Expect(container.Mounts).To(ContainElement(&pluginapi.Mount{
+			ContainerPath: "/bin/nvidia-smi",
+			HostPath:      "/var/lib/runai/bin/nvidia-smi",
+		}))
+	})
+})

--- a/internal/deviceplugin/real_node_test.go
+++ b/internal/deviceplugin/real_node_test.go
@@ -31,10 +31,7 @@ var _ = Describe("RealNodeDevicePlugin Allocate", func() {
 		Expect(resp.ContainerResponses).To(HaveLen(1))
 
 		container := resp.ContainerResponses[0]
-		// The actual fix for RUN-39004: NODE_NAME must be propagated so nvidia-smi
-		// can resolve its node topology instead of querying an empty node.
 		Expect(container.Envs).To(HaveKeyWithValue(constants.EnvNodeName, nodeName))
-		// Pre-existing behavior must be preserved.
 		Expect(container.Envs).To(HaveKeyWithValue("MOCK_NVIDIA_VISIBLE_DEVICES", "gpu-0,gpu-1"))
 		Expect(container.Mounts).To(ContainElement(&pluginapi.Mount{
 			ContainerPath: "/bin/nvidia-smi",

--- a/test/e2e/device_plugin_test.go
+++ b/test/e2e/device_plugin_test.go
@@ -12,20 +12,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Covers the legacy (non-DRA) device-plugin path, which the rest of this suite does not
-// exercise: it allocates GPUs via the nvidia.com/gpu extended resource served by the fake
-// RealNodeDevicePlugin on the real worker, rather than via ResourceClaims on KWOK nodes.
-//
-// Regression guard for RUN-39004: before the fix, Allocate() didn't inject NODE_NAME, so
-// the in-container /bin/nvidia-smi queried an empty node, got a non-JSON error from
-// topology-server, and panicked ("invalid character 'C' looking for beginning of value").
+// Regression guard for RUN-39004: covers the legacy (non-DRA) device-plugin path, where
+// a pod gets its GPU via the nvidia.com/gpu extended resource and runs the fake nvidia-smi.
 var _ = Describe("Device-Plugin Path Tests", func() {
 	var testNamespaces []string
 
 	BeforeEach(func() {
-		// The legacy device-plugin runs only when devicePlugin.enabled=true (values.yaml).
-		// Other suites that share this package (e.g. make e2e-profiles) leave it disabled, so
-		// skip rather than fail when the daemonset isn't deployed.
+		// Skip in suites that don't enable the device-plugin (e.g. make e2e-profiles).
 		_, err := kubeClient.AppsV1().DaemonSets("gpu-operator").Get(context.Background(), "device-plugin", metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			Skip("device-plugin daemonset not deployed (devicePlugin.enabled=false) — skipping legacy device-plugin path test")
@@ -47,22 +40,17 @@ var _ = Describe("Device-Plugin Path Tests", func() {
 			podName := "device-plugin-pod0"
 
 			setupTest(manifestPath, namespace, &testNamespaces)
-			// No ResourceClaims on this path — waitForPodReady handles that and just waits
-			// for the pod to be Running/Ready once the device-plugin allocates the GPU.
 			waitForPodReady(namespace, podName, podReadyTimeout)
 
 			verifyNvidiaSmiBinary(namespace, podName, "ctr0")
 
-			// runNvidiaSmi asserts a zero exit code, so a panic (the RUN-39004 bug) fails here.
 			output := runNvidiaSmi(namespace, podName, "ctr0")
-			Expect(output).NotTo(ContainSubstring("panic"), "nvidia-smi must not panic (RUN-39004)")
-			Expect(output).NotTo(ContainSubstring("invalid character"), "nvidia-smi must not hit the JSON-decode panic (RUN-39004)")
-			Expect(strings.ToUpper(output)).To(ContainSubstring("NVIDIA-SMI"), "nvidia-smi should render its header")
-			// The product column is truncated to 12 chars by sizeString, so match the prefix.
-			Expect(output).To(ContainSubstring(expectedGpuProduct[:10]), "nvidia-smi should report the default pool's GPU product")
-			// 40960 is the default pool's gpuMemory; rendering it proves nvidia-smi resolved
-			// THIS node's topology, which only works because NODE_NAME was injected (RUN-39004).
-			Expect(output).To(ContainSubstring("40960MiB"), "nvidia-smi should report the default pool's GPU memory")
+			Expect(output).NotTo(ContainSubstring("panic"))
+			Expect(strings.ToUpper(output)).To(ContainSubstring("NVIDIA-SMI"))
+			// Product column is truncated to 12 chars by sizeString, so match the prefix.
+			Expect(output).To(ContainSubstring(expectedGpuProduct[:10]))
+			// 40960 = default pool gpuMemory; proves nvidia-smi resolved this node's topology.
+			Expect(output).To(ContainSubstring("40960MiB"))
 		})
 	})
 })

--- a/test/e2e/device_plugin_test.go
+++ b/test/e2e/device_plugin_test.go
@@ -1,0 +1,53 @@
+package e2e_test
+
+import (
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Covers the legacy (non-DRA) device-plugin path, which the rest of this suite does not
+// exercise: it allocates GPUs via the nvidia.com/gpu extended resource served by the fake
+// RealNodeDevicePlugin on the real worker, rather than via ResourceClaims on KWOK nodes.
+//
+// Regression guard for RUN-39004: before the fix, Allocate() didn't inject NODE_NAME, so
+// the in-container /bin/nvidia-smi queried an empty node, got a non-JSON error from
+// topology-server, and panicked ("invalid character 'C' looking for beginning of value").
+var _ = Describe("Device-Plugin Path Tests", func() {
+	var testNamespaces []string
+
+	AfterEach(func() {
+		for _, ns := range testNamespaces {
+			deleteNamespace(ns)
+		}
+		testNamespaces = nil
+	})
+
+	Describe("nvidia-smi on a non-DRA GPU pod", func() {
+		It("runs /bin/nvidia-smi without panicking and reports the pool's GPU", func() {
+			manifestPath := filepath.Join("fixtures", "manifests", "device-plugin-pod.yaml")
+			namespace := "gpu-test-device-plugin"
+			podName := "device-plugin-pod0"
+
+			setupTest(manifestPath, namespace, &testNamespaces)
+			// No ResourceClaims on this path — waitForPodReady handles that and just waits
+			// for the pod to be Running/Ready once the device-plugin allocates the GPU.
+			waitForPodReady(namespace, podName, podReadyTimeout)
+
+			verifyNvidiaSmiBinary(namespace, podName, "ctr0")
+
+			// runNvidiaSmi asserts a zero exit code, so a panic (the RUN-39004 bug) fails here.
+			output := runNvidiaSmi(namespace, podName, "ctr0")
+			Expect(output).NotTo(ContainSubstring("panic"), "nvidia-smi must not panic (RUN-39004)")
+			Expect(output).NotTo(ContainSubstring("invalid character"), "nvidia-smi must not hit the JSON-decode panic (RUN-39004)")
+			Expect(strings.ToUpper(output)).To(ContainSubstring("NVIDIA-SMI"), "nvidia-smi should render its header")
+			// The product column is truncated to 12 chars by sizeString, so match the prefix.
+			Expect(output).To(ContainSubstring(expectedGpuProduct[:10]), "nvidia-smi should report the default pool's GPU product")
+			// 40960 is the default pool's gpuMemory; rendering it proves nvidia-smi resolved
+			// THIS node's topology, which only works because NODE_NAME was injected (RUN-39004).
+			Expect(output).To(ContainSubstring("40960MiB"), "nvidia-smi should report the default pool's GPU memory")
+		})
+	})
+})

--- a/test/e2e/device_plugin_test.go
+++ b/test/e2e/device_plugin_test.go
@@ -1,11 +1,15 @@
 package e2e_test
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Covers the legacy (non-DRA) device-plugin path, which the rest of this suite does not
@@ -17,6 +21,17 @@ import (
 // topology-server, and panicked ("invalid character 'C' looking for beginning of value").
 var _ = Describe("Device-Plugin Path Tests", func() {
 	var testNamespaces []string
+
+	BeforeEach(func() {
+		// The legacy device-plugin runs only when devicePlugin.enabled=true (values.yaml).
+		// Other suites that share this package (e.g. make e2e-profiles) leave it disabled, so
+		// skip rather than fail when the daemonset isn't deployed.
+		_, err := kubeClient.AppsV1().DaemonSets("gpu-operator").Get(context.Background(), "device-plugin", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			Skip("device-plugin daemonset not deployed (devicePlugin.enabled=false) — skipping legacy device-plugin path test")
+		}
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	AfterEach(func() {
 		for _, ns := range testNamespaces {

--- a/test/e2e/fixtures/manifests/device-plugin-pod.yaml
+++ b/test/e2e/fixtures/manifests/device-plugin-pod.yaml
@@ -1,0 +1,26 @@
+# Non-DRA pod exercising the legacy device-plugin path (RUN-39004).
+# Requests the nvidia.com/gpu extended resource (NOT a ResourceClaim), which the fake
+# RealNodeDevicePlugin advertises on the real worker. Allocate() bind-mounts
+# /bin/nvidia-smi and injects NODE_NAME so the in-container nvidia-smi can resolve its
+# node topology instead of panicking on an empty-node response.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-test-device-plugin
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: gpu-test-device-plugin
+  name: device-plugin-pod0
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      limits:
+        nvidia.com/gpu: "1"

--- a/test/e2e/fixtures/manifests/device-plugin-pod.yaml
+++ b/test/e2e/fixtures/manifests/device-plugin-pod.yaml
@@ -1,8 +1,4 @@
-# Non-DRA pod exercising the legacy device-plugin path (RUN-39004).
-# Requests the nvidia.com/gpu extended resource (NOT a ResourceClaim), which the fake
-# RealNodeDevicePlugin advertises on the real worker. Allocate() bind-mounts
-# /bin/nvidia-smi and injects NODE_NAME so the in-container nvidia-smi can resolve its
-# node topology instead of panicking on an empty-node response.
+# Non-DRA pod: requests the nvidia.com/gpu extended resource (not a ResourceClaim).
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/test/e2e/fixtures/values.yaml
+++ b/test/e2e/fixtures/values.yaml
@@ -30,9 +30,14 @@ topologyServer:
 topologyConfigMap:
   enabled: true
 
-# Disable components not needed for e2e tests
+# Enable the legacy device-plugin path so its nvidia-smi behavior is covered (RUN-39004).
+# The daemonset is gated by the nvidia.com/gpu.deploy.device-plugin nodeSelector, which
+# status-updater sets only on the real (non-KWOK) worker — so it stays confined to that
+# node and does not affect the KWOK-based DRA tests.
 devicePlugin:
-  enabled: false
+  enabled: true
+  image:
+    pullPolicy: Never
 
 statusExporter:
   enabled: true

--- a/test/e2e/fixtures/values.yaml
+++ b/test/e2e/fixtures/values.yaml
@@ -30,10 +30,8 @@ topologyServer:
 topologyConfigMap:
   enabled: true
 
-# Enable the legacy device-plugin path so its nvidia-smi behavior is covered (RUN-39004).
-# The daemonset is gated by the nvidia.com/gpu.deploy.device-plugin nodeSelector, which
-# status-updater sets only on the real (non-KWOK) worker — so it stays confined to that
-# node and does not affect the KWOK-based DRA tests.
+# Enabled to cover the legacy device-plugin nvidia-smi path (gated to the real worker
+# by the nvidia.com/gpu.deploy.device-plugin nodeSelector, so KWOK/DRA tests are unaffected).
 devicePlugin:
   enabled: true
   image:

--- a/test/e2e/scripts/setup.sh
+++ b/test/e2e/scripts/setup.sh
@@ -102,11 +102,7 @@ if [[ "${SKIP_SETUP}" != "true" ]]; then
     echo "Waiting for status-updater pod to be ready..."
     kubectl wait --for=condition=Ready pod -l app=status-updater -n gpu-operator --timeout=120s
 
-    # Only present when devicePlugin.enabled=true (e.g. values.yaml, not values-profiles.yaml).
-    # The daemonset schedules on the real worker (status-updater labels it
-    # nvidia.com/gpu.deploy.device-plugin=true) and exits(1) until status-updater creates the
-    # node topology CM, so it may restart once before settling — rollout status waits for the
-    # eventual Ready pod.
+    # Present only when devicePlugin.enabled=true (values.yaml, not values-profiles.yaml).
     if kubectl get daemonset/device-plugin -n gpu-operator >/dev/null 2>&1; then
         echo "Waiting for device-plugin daemonset to be ready..."
         kubectl rollout status daemonset/device-plugin -n gpu-operator --timeout=180s

--- a/test/e2e/scripts/setup.sh
+++ b/test/e2e/scripts/setup.sh
@@ -102,12 +102,15 @@ if [[ "${SKIP_SETUP}" != "true" ]]; then
     echo "Waiting for status-updater pod to be ready..."
     kubectl wait --for=condition=Ready pod -l app=status-updater -n gpu-operator --timeout=120s
 
-    # The device-plugin daemonset schedules on the real worker (status-updater labels it
-    # nvidia.com/gpu.deploy.device-plugin=true) and exits(1) until status-updater creates
-    # the node topology CM, so it may restart once before settling — rollout status waits
-    # for the eventual Ready pod.
-    echo "Waiting for device-plugin daemonset to be ready..."
-    kubectl rollout status daemonset/device-plugin -n gpu-operator --timeout=180s
+    # Only present when devicePlugin.enabled=true (e.g. values.yaml, not values-profiles.yaml).
+    # The daemonset schedules on the real worker (status-updater labels it
+    # nvidia.com/gpu.deploy.device-plugin=true) and exits(1) until status-updater creates the
+    # node topology CM, so it may restart once before settling — rollout status waits for the
+    # eventual Ready pod.
+    if kubectl get daemonset/device-plugin -n gpu-operator >/dev/null 2>&1; then
+        echo "Waiting for device-plugin daemonset to be ready..."
+        kubectl rollout status daemonset/device-plugin -n gpu-operator --timeout=180s
+    fi
 
     echo "Waiting for status-exporter pod to be ready..."
     kubectl wait --for=condition=Ready pod -l app=nvidia-dcgm-exporter -n gpu-operator --timeout=120s

--- a/test/e2e/scripts/setup.sh
+++ b/test/e2e/scripts/setup.sh
@@ -57,7 +57,7 @@ if [[ "${SKIP_SETUP}" != "true" ]]; then
 
     echo "Loading images into kind cluster..."
     DOCKER_REPO_BASE="${DOCKER_REPO_BASE:-ghcr.io/run-ai/fake-gpu-operator}"
-    for component in dra-plugin-gpu status-updater status-exporter topology-server kwok-dra-plugin kwok-compute-domain-dra-plugin compute-domain-controller compute-domain-dra-plugin; do
+    for component in device-plugin dra-plugin-gpu status-updater status-exporter topology-server kwok-dra-plugin kwok-compute-domain-dra-plugin compute-domain-controller compute-domain-dra-plugin; do
         IMAGE="${DOCKER_REPO_BASE}/${component}:${DOCKER_TAG}"
         echo "Loading ${IMAGE}..."
         kind load docker-image \
@@ -89,6 +89,7 @@ if [[ "${SKIP_SETUP}" != "true" ]]; then
         --namespace gpu-operator \
         --create-namespace \
         -f "${VALUES_FILE}" \
+        --set devicePlugin.image.tag="${DOCKER_TAG}" \
         --set draPlugin.image.tag="${DOCKER_TAG}" \
         --set statusUpdater.image.tag="${DOCKER_TAG}" \
         --set statusExporter.image.tag="${DOCKER_TAG}" \
@@ -100,6 +101,13 @@ if [[ "${SKIP_SETUP}" != "true" ]]; then
 
     echo "Waiting for status-updater pod to be ready..."
     kubectl wait --for=condition=Ready pod -l app=status-updater -n gpu-operator --timeout=120s
+
+    # The device-plugin daemonset schedules on the real worker (status-updater labels it
+    # nvidia.com/gpu.deploy.device-plugin=true) and exits(1) until status-updater creates
+    # the node topology CM, so it may restart once before settling — rollout status waits
+    # for the eventual Ready pod.
+    echo "Waiting for device-plugin daemonset to be ready..."
+    kubectl rollout status daemonset/device-plugin -n gpu-operator --timeout=180s
 
     echo "Waiting for status-exporter pod to be ready..."
     kubectl wait --for=condition=Ready pod -l app=nvidia-dcgm-exporter -n gpu-operator --timeout=120s


### PR DESCRIPTION
## Description

The legacy device-plugin `Allocate()` (`internal/deviceplugin/real_node.go`) injected `MOCK_NVIDIA_VISIBLE_DEVICES` and the `/bin/nvidia-smi` bind-mount but **never `NODE_NAME`**. A non-DRA pod requesting `nvidia.com/gpu` and running `/bin/nvidia-smi` therefore queried `topology-server` with an empty node segment (`.../topology/nodes/`), received a plain-text `400 Can't get node name from url ...`, and panicked decoding it as JSON:

```
panic: invalid character 'C' looking for beginning of value
```

The DRA path is immune because its CDI spec already injects `NODE_NAME` (`internal/dra-plugin-gpu/cdi.go`). This change closes that single parity gap.

### Changes
- **`real_node.go`** — inject `NODE_NAME` (`constants.EnvNodeName`) into the workload env. The device-plugin DaemonSet already receives it via the downward API (`spec.nodeName`), and as a DaemonSet runs on the same node as the pods it serves.
- **`cmd/nvidia-smi/main.go`** — close the response body and fail with a clear message on non-2xx topology responses, instead of a cryptic JSON-decode panic.
- **Tests** — unit test for `Allocate()`; new e2e regression spec that enables the device-plugin path in `make e2e` and runs `nvidia-smi` in a non-DRA `nvidia.com/gpu` pod.

`POD_UUID` is intentionally **out of scope**: it isn't available from the kubelet `Allocate` gRPC, and the DRA path doesn't inject it either.

### Verified before/after on a local kind cluster
- **Without the fix:** the new e2e spec FAILS with `panic: invalid character 'C'`.
- **With the fix:** it PASSES — `nvidia-smi` renders the table (header, `NVIDIA A10..`, `40960MiB`), no panic.

Until now no e2e suite exercised the legacy device-plugin path (`devicePlugin.enabled=false` everywhere except upgrade, which doesn't run `nvidia-smi`), which is why this regression shipped without CI catching it. This PR adds that coverage.

## Related Issues

Fixes #191

(internal: RUN-39004)

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`

## Breaking Changes

None.

## Additional Notes

The e2e pod lands on the real worker (not a KWOK node): KWOK nodes carry a `NoSchedule` taint and advertise no `nvidia.com/gpu`, so a pod requesting that resource can only schedule where the device-plugin runs and a real container executes. status-updater auto-labels the real node `nvidia.com/gpu.deploy.device-plugin=true` and creates its topology CM, so no manual node wiring is needed.