### PR TITLE
mig faker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,29 @@ jobs:
           DOCKER_REPO_BASE: ghcr.io/run-ai/fake-gpu-operator
           DOCKER_BUILDX_PLATFORMS: linux/amd64
 
+  e2e-device-plugin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install kind
+        uses: helm/kind-action@v1.13.0
+        with:
+          install_only: true
+      - name: Run device-plugin / mig-faker e2e tests
+        run: make e2e-device-plugin
+        env:
+          DOCKER_TAG: 0.0.0-dev
+          DOCKER_REPO_BASE: ghcr.io/run-ai/fake-gpu-operator
+          DOCKER_BUILDX_PLATFORMS: linux/amd64
+
   e2e-upgrade:
     name: e2e-upgrade (${{ matrix.name }})
     runs-on: ubuntu-latest
@@ -208,7 +231,7 @@ jobs:
 
   release-docker:
     runs-on: ubuntu-latest
-    needs: [set-release-vars, lint, test, e2e, e2e-profiles, e2e-mock, e2e-upgrade]
+    needs: [set-release-vars, lint, test, e2e, e2e-profiles, e2e-mock, e2e-device-plugin, e2e-upgrade]
     if: ${{ needs.set-release-vars.outputs.release_version != '' }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,29 @@ jobs:
           DOCKER_REPO_BASE: ghcr.io/run-ai/fake-gpu-operator
           DOCKER_BUILDX_PLATFORMS: linux/amd64
 
+  e2e-device-plugin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install kind
+        uses: helm/kind-action@v1.13.0
+        with:
+          install_only: true
+      - name: Run device-plugin / mig-faker e2e tests
+        run: make e2e-device-plugin
+        env:
+          DOCKER_TAG: 0.0.0-dev
+          DOCKER_REPO_BASE: ghcr.io/run-ai/fake-gpu-operator
+          DOCKER_BUILDX_PLATFORMS: linux/amd64
+
   set-release-vars:
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || inputs.release_tag != '' }}
     runs-on: ubuntu-latest
@@ -139,7 +162,7 @@ jobs:
 
   release-docker:
     runs-on: ubuntu-latest
-    needs: [set-release-vars, lint, test, e2e, e2e-profiles, e2e-mock]
+    needs: [set-release-vars, lint, test, e2e, e2e-profiles, e2e-mock, e2e-device-plugin]
     if: ${{ needs.set-release-vars.outputs.release_version != '' }}
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,21 @@ teardown-e2e-mock:
 e2e-mock: setup-e2e-mock test-e2e-mock teardown-e2e-mock
 .PHONY: e2e-mock
 
+setup-e2e-device-plugin: ginkgo
+	test/e2e/device-plugin/scripts/setup.sh
+.PHONY: setup-e2e-device-plugin
+
+test-e2e-device-plugin: ginkgo
+	cd test/e2e/device-plugin && $(GINKGO) --procs=1 --timeout=30m --trace
+.PHONY: test-e2e-device-plugin
+
+teardown-e2e-device-plugin:
+	test/e2e/device-plugin/scripts/teardown.sh
+.PHONY: teardown-e2e-device-plugin
+
+e2e-device-plugin: setup-e2e-device-plugin test-e2e-device-plugin teardown-e2e-device-plugin
+.PHONY: e2e-device-plugin
+
 clean:
 	rm -rf ${BUILD_DIR}
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,21 @@ teardown-e2e-mock:
 e2e-mock: setup-e2e-mock test-e2e-mock teardown-e2e-mock
 .PHONY: e2e-mock
 
+setup-e2e-device-plugin: ginkgo
+	test/e2e/device-plugin/scripts/setup.sh
+.PHONY: setup-e2e-device-plugin
+
+test-e2e-device-plugin: ginkgo
+	cd test/e2e/device-plugin && $(GINKGO) --procs=1 --timeout=30m --trace
+.PHONY: test-e2e-device-plugin
+
+teardown-e2e-device-plugin:
+	test/e2e/device-plugin/scripts/teardown.sh
+.PHONY: teardown-e2e-device-plugin
+
+e2e-device-plugin: setup-e2e-device-plugin test-e2e-device-plugin teardown-e2e-device-plugin
+.PHONY: e2e-device-plugin
+
 # The upgrade suite is split into three stages so the inner loop is fast:
 #   make setup-e2e-upgrade    — kind cluster + baseline OCI install   (~3 min, once)
 #   make upgrade-e2e-upgrade  — helm upgrade to local HEAD chart      (~30s,  per chart edit)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,90 @@ When requests flow to this inference pod, GPU utilization metrics will reflect t
 - `workloadKind: "InferenceWorkload"` - Single-node inference with Knative metrics
 - `workloadKind: "DistributedWorkload"` - Distributed inference with Knative metrics
 
+## 🧩 NVIDIA MIG (Multi-Instance GPU)
+
+The Fake GPU Operator can simulate [MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) so that a single simulated GPU is published to the scheduler as its individual MIG slices (e.g. `nvidia.com/mig-1g.5gb`). This runs on the **legacy device-plugin path** (not DRA), driven by the `mig-faker` component.
+
+> **Note:** MIG resource _scheduling_ is supported; per-slice metrics monitoring is not yet supported.
+
+### 1. Enable the device plugin and the `mixed` MIG strategy
+
+MIG uses the device plugin, so make sure the DRA plugin is disabled. Set `migStrategy: mixed` so MIG-enabled GPUs are advertised as their individual profiles:
+
+```yaml
+# values.yaml
+devicePlugin:
+  enabled: true
+migFaker:
+  enabled: true
+draPlugin:
+  enabled: false  # device-plugin and DRA are mutually exclusive
+topology:
+  migStrategy: mixed
+  nodePools:
+    mig-pool:
+      gpuProduct: NVIDIA-A100-SXM4-40GB
+      gpuCount: 1
+      gpuMemory: 40960
+```
+
+### 2. Label the node
+
+In addition to the node-pool label, label the node so `mig-faker` runs on it:
+
+```bash
+kubectl label node <node-name> run.ai/simulated-gpu-node-pool=mig-pool --overwrite
+kubectl label node <node-name> node-role.kubernetes.io/runai-dynamic-mig=true --overwrite
+```
+
+### 3. Apply a MIG config annotation
+
+`mig-faker` watches the `run.ai/mig.config` node annotation. Its value is a YAML document that selects which GPU indices to slice and into which profiles. For example, to slice GPU `0` into seven `1g.5gb` instances:
+
+```bash
+kubectl annotate node <node-name> run.ai/mig.config='
+version: v1
+mig-configs:
+  selected:
+  - devices: ["0"]          # GPU indices to enable MIG on; use ["all"] for every GPU
+    mig-enabled: true
+    mig-devices:
+    - {name: 1g.5gb, position: 0, size: 1}
+    - {name: 1g.5gb, position: 1, size: 1}
+    - {name: 1g.5gb, position: 2, size: 1}
+    - {name: 1g.5gb, position: 3, size: 1}
+    - {name: 1g.5gb, position: 4, size: 1}
+    - {name: 1g.5gb, position: 5, size: 1}
+    - {name: 1g.5gb, position: 6, size: 1}
+' --overwrite
+```
+
+`devices` entries are GPU indices as strings (or `["all"]`). Valid profile `name`s depend on the GPU product (e.g. `1g.5gb`, `2g.10gb`, `3g.20gb` for A100-40GB).
+
+`mig-faker` then marks the node with `nvidia.com/mig.config.state: success`, records the slices in the node's topology ConfigMap, and restarts the device-plugin pod so kubelet picks up the new resources.
+
+### 4. Verify and schedule
+
+```bash
+kubectl get node <node-name> -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep nvidia
+# nvidia.com/mig-1g.5gb":"7"
+```
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mig-pod
+spec:
+  containers:
+  - name: main
+    image: ubuntu:22.04
+    command: ["sleep", "infinity"]
+    resources:
+      limits:
+        nvidia.com/mig-1g.5gb: 1
+```
+
 ## 🔌 Dynamic Resource Allocation (DRA)
 
 For Kubernetes 1.31+, you can use the DRA plugin instead of the legacy device plugin.

--- a/cmd/device-plugin/main.go
+++ b/cmd/device-plugin/main.go
@@ -42,13 +42,21 @@ func main() {
 	initNvidiaSmi()
 	initPreloaders()
 
+	if err := deviceplugin.CleanupStaleSockets(); err != nil {
+		log.Printf("Failed to clean stale device-plugin sockets: %s\n", err)
+		os.Exit(1)
+	}
+
 	devicePlugins := deviceplugin.NewDevicePlugins(topology, kubeClient)
 	for _, devicePlugin := range devicePlugins {
-		log.Printf("Starting device plugin for %s\n", devicePlugin.Name())
-		if err = devicePlugin.Serve(); err != nil {
-			log.Printf("Failed to serve device plugin: %s\n", err)
-			os.Exit(1)
-		}
+		plugin := devicePlugin
+		go func() {
+			log.Printf("Starting device plugin for %s\n", plugin.Name())
+			if err := plugin.Serve(); err != nil {
+				log.Printf("Failed to serve device plugin %s: %s\n", plugin.Name(), err)
+				os.Exit(1)
+			}
+		}()
 	}
 
 	sig := make(chan os.Signal, 1)

--- a/deploy/fake-gpu-operator/templates/mig-faker/clusterrole.yaml
+++ b/deploy/fake-gpu-operator/templates/mig-faker/clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
     verbs:
       - get
       - update
+      - patch
       - watch
       - list
   - apiGroups:
@@ -22,4 +23,11 @@ rules:
       - update
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - delete
 {{- end -}}

--- a/deploy/fake-gpu-operator/templates/mig-faker/daemonset.yml
+++ b/deploy/fake-gpu-operator/templates/mig-faker/daemonset.yml
@@ -37,6 +37,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TOPOLOGY_CM_NAME
+              value: topology
+            - name: TOPOLOGY_CM_NAMESPACE
+              value: "{{ .Release.Namespace }}"
           name: mig-faker
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -49,4 +53,3 @@ spec:
       imagePullSecrets:
         - name: gcr-secret
 {{- end -}}
-

--- a/internal/common/topology/resources.go
+++ b/internal/common/topology/resources.go
@@ -1,0 +1,80 @@
+package topology
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/run-ai/fake-gpu-operator/internal/common/constants"
+)
+
+const migResourcePrefix = "nvidia.com/mig-"
+
+// MigResourceName returns the Kubernetes extended resource name for a MIG
+// profile, for example "1g.5gb" -> "nvidia.com/mig-1g.5gb".
+func MigResourceName(profile string) string {
+	return migResourcePrefix + profile
+}
+
+// AdvertisedResources returns the resources that should be exposed to the
+// Kubernetes scheduler for this node topology.
+func AdvertisedResources(nodeTopology *NodeTopology) []GenericDevice {
+	if nodeTopology == nil {
+		return nil
+	}
+
+	counts := map[string]int{}
+	switch strings.ToLower(nodeTopology.MigStrategy) {
+	case "mixed":
+		for _, gpu := range nodeTopology.Gpus {
+			if gpu.MigEnabled {
+				for _, migInstance := range gpu.MigInstances {
+					if migInstance.Profile == "" {
+						continue
+					}
+					counts[MigResourceName(migInstance.Profile)]++
+				}
+				continue
+			}
+			counts[constants.GpuResourceName]++
+		}
+	case "single":
+		count := 0
+		for _, gpu := range nodeTopology.Gpus {
+			if gpu.MigEnabled {
+				count += len(gpu.MigInstances)
+				continue
+			}
+			count++
+		}
+		counts[constants.GpuResourceName] = count
+	default:
+		counts[constants.GpuResourceName] = len(nodeTopology.Gpus)
+	}
+
+	for _, device := range nodeTopology.OtherDevices {
+		if device.Name == "" || device.Count <= 0 {
+			continue
+		}
+		counts[device.Name] += device.Count
+	}
+
+	resources := make([]GenericDevice, 0, len(counts))
+	for name, count := range counts {
+		if count <= 0 && name != constants.GpuResourceName {
+			continue
+		}
+		resources = append(resources, GenericDevice{Name: name, Count: count})
+	}
+
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].Name == constants.GpuResourceName {
+			return true
+		}
+		if resources[j].Name == constants.GpuResourceName {
+			return false
+		}
+		return resources[i].Name < resources[j].Name
+	})
+
+	return resources
+}

--- a/internal/common/topology/resources_test.go
+++ b/internal/common/topology/resources_test.go
@@ -62,6 +62,35 @@ func TestAdvertisedResourcesMixedStrategy(t *testing.T) {
 	}
 }
 
+func TestAdvertisedResourcesSingleStrategy(t *testing.T) {
+	// In "single" strategy, MIG slices are advertised as plain nvidia.com/gpu
+	// (count = number of slices), not as nvidia.com/mig-<profile>.
+	nodeTopology := &NodeTopology{
+		MigStrategy: "single",
+		Gpus: []GpuDetails{
+			{
+				ID:         "GPU-0",
+				MigEnabled: true,
+				MigInstances: []MigInstance{
+					{Profile: "1g.5gb"},
+					{Profile: "1g.5gb"},
+					{Profile: "1g.5gb"},
+				},
+			},
+			{ID: "GPU-1"},
+		},
+	}
+
+	resources := AdvertisedResources(nodeTopology)
+	if len(resources) != 1 {
+		t.Fatalf("AdvertisedResources length = %d, want 1", len(resources))
+	}
+	// 3 slices on GPU-0 + 1 whole GPU-1 = 4 generic GPUs.
+	if resources[0] != (GenericDevice{Name: constants.GpuResourceName, Count: 4}) {
+		t.Fatalf("GPU resource = %+v, want nvidia.com/gpu=4", resources[0])
+	}
+}
+
 func TestAdvertisedResourcesMixedAllMigOmitsGpu(t *testing.T) {
 	nodeTopology := &NodeTopology{
 		MigStrategy: "mixed",

--- a/internal/common/topology/resources_test.go
+++ b/internal/common/topology/resources_test.go
@@ -1,0 +1,86 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/run-ai/fake-gpu-operator/internal/common/constants"
+)
+
+func TestAdvertisedResourcesNoneStrategy(t *testing.T) {
+	nodeTopology := &NodeTopology{
+		MigStrategy: "none",
+		Gpus: []GpuDetails{
+			{ID: "GPU-0"},
+			{ID: "GPU-1"},
+		},
+		OtherDevices: []GenericDevice{
+			{Name: "rdma/hca", Count: 2},
+		},
+	}
+
+	resources := AdvertisedResources(nodeTopology)
+	if len(resources) != 2 {
+		t.Fatalf("AdvertisedResources length = %d, want 2", len(resources))
+	}
+	if resources[0] != (GenericDevice{Name: constants.GpuResourceName, Count: 2}) {
+		t.Fatalf("GPU resource = %+v, want nvidia.com/gpu=2", resources[0])
+	}
+	if resources[1] != (GenericDevice{Name: "rdma/hca", Count: 2}) {
+		t.Fatalf("other resource = %+v, want rdma/hca=2", resources[1])
+	}
+}
+
+func TestAdvertisedResourcesMixedStrategy(t *testing.T) {
+	nodeTopology := &NodeTopology{
+		MigStrategy: "mixed",
+		Gpus: []GpuDetails{
+			{
+				ID:         "GPU-0",
+				MigEnabled: true,
+				MigInstances: []MigInstance{
+					{Profile: "1g.5gb"},
+					{Profile: "1g.5gb"},
+					{Profile: "2g.10gb"},
+				},
+			},
+			{ID: "GPU-1"},
+		},
+	}
+
+	resources := AdvertisedResources(nodeTopology)
+	if len(resources) != 3 {
+		t.Fatalf("AdvertisedResources length = %d, want 3", len(resources))
+	}
+	if resources[0] != (GenericDevice{Name: constants.GpuResourceName, Count: 1}) {
+		t.Fatalf("GPU resource = %+v, want nvidia.com/gpu=1", resources[0])
+	}
+	if resources[1] != (GenericDevice{Name: "nvidia.com/mig-1g.5gb", Count: 2}) {
+		t.Fatalf("first MIG resource = %+v, want nvidia.com/mig-1g.5gb=2", resources[1])
+	}
+	if resources[2] != (GenericDevice{Name: "nvidia.com/mig-2g.10gb", Count: 1}) {
+		t.Fatalf("second MIG resource = %+v, want nvidia.com/mig-2g.10gb=1", resources[2])
+	}
+}
+
+func TestAdvertisedResourcesMixedAllMigOmitsGpu(t *testing.T) {
+	nodeTopology := &NodeTopology{
+		MigStrategy: "mixed",
+		Gpus: []GpuDetails{
+			{
+				ID:         "GPU-0",
+				MigEnabled: true,
+				MigInstances: []MigInstance{
+					{Profile: "1g.5gb"},
+				},
+			},
+		},
+	}
+
+	resources := AdvertisedResources(nodeTopology)
+	if len(resources) != 1 {
+		t.Fatalf("AdvertisedResources length = %d, want 1", len(resources))
+	}
+	if resources[0] != (GenericDevice{Name: "nvidia.com/mig-1g.5gb", Count: 1}) {
+		t.Fatalf("MIG resource = %+v, want nvidia.com/mig-1g.5gb=1", resources[0])
+	}
+}

--- a/internal/common/topology/types.go
+++ b/internal/common/topology/types.go
@@ -23,13 +23,13 @@ type NodePoolTopology struct {
 type ClusterConfig struct {
 	NodePoolLabelKey string                    `yaml:"nodePoolLabelKey"`
 	MigStrategy      string                    `yaml:"migStrategy"`
-	NodePools        map[string]NodePoolConfig  `yaml:"nodePools"`
-	GpuOperator      *GpuOperatorConfig         `yaml:"gpuOperator,omitempty"`
+	NodePools        map[string]NodePoolConfig `yaml:"nodePools"`
+	GpuOperator      *GpuOperatorConfig        `yaml:"gpuOperator,omitempty"`
 }
 
 type NodePoolConfig struct {
-	Gpu       GpuConfig          `yaml:"gpu"`
-	Resources []map[string]int   `yaml:"resources,omitempty"`
+	Gpu       GpuConfig        `yaml:"gpu"`
+	Resources []map[string]int `yaml:"resources,omitempty"`
 }
 
 type GpuConfig struct {
@@ -53,6 +53,28 @@ type NodeTopology struct {
 
 type GpuDetails struct {
 	ID     string    `yaml:"id"`
+	Status GpuStatus `yaml:"status"`
+
+	// MigEnabled marks this physical GPU as sliced. Per NVIDIA convention a
+	// MIG-enabled GPU contributes 0 to nvidia.com/gpu — its slices show up
+	// individually under nvidia.com/mig-<profile> when migStrategy is "mixed".
+	MigEnabled bool `yaml:"migEnabled,omitempty"`
+
+	// MigInstances enumerates the slices on this GPU (empty when !MigEnabled).
+	// The list is the source of truth for per-slice allocation; advertised
+	// resource counts are computed from it by AdvertisedResources.
+	MigInstances []MigInstance `yaml:"migInstances,omitempty"`
+}
+
+// MigInstance describes a single MIG slice on a physical GPU.
+type MigInstance struct {
+	// Profile is the NVIDIA MIG profile name, e.g. "1g.5gb", "2g.10gb".
+	Profile string `yaml:"profile"`
+	// Index is the slot of this slice within the parent GPU (0-based).
+	Index int `yaml:"index"`
+	// UUID is what NVML would report for this slice — format "MIG-<uuid>".
+	UUID string `yaml:"uuid"`
+	// Status mirrors GpuStatus's shape — per-slice allocation + usage tracking.
 	Status GpuStatus `yaml:"status"`
 }
 

--- a/internal/deviceplugin/device_plugin.go
+++ b/internal/deviceplugin/device_plugin.go
@@ -1,7 +1,9 @@
 package deviceplugin
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/run-ai/fake-gpu-operator/internal/common/constants"
@@ -20,41 +22,58 @@ type Interface interface {
 	Name() string
 }
 
-func NewDevicePlugins(topology *topology.NodeTopology, kubeClient kubernetes.Interface) []Interface {
-	if topology == nil {
+func NewDevicePlugins(nodeTopology *topology.NodeTopology, kubeClient kubernetes.Interface) []Interface {
+	if nodeTopology == nil {
 		panic("topology is nil")
 	}
 
+	resources := topology.AdvertisedResources(nodeTopology)
 	if viper.GetBool(constants.EnvFakeNode) {
-		otherDevices := make(map[string]int)
-		for _, genericDevice := range topology.OtherDevices {
-			otherDevices[genericDevice.Name] = genericDevice.Count
+		deviceResources := make(map[string]int)
+		for _, resource := range resources {
+			deviceResources[resource.Name] = resource.Count
 		}
 
 		return []Interface{&FakeNodeDevicePlugin{
-			kubeClient:   kubeClient,
-			gpuCount:     getGpuCount(topology),
-			otherDevices: otherDevices,
+			kubeClient: kubeClient,
+			resources:  deviceResources,
 		}}
 	}
 
-	devicePlugins := []Interface{
-		&RealNodeDevicePlugin{
-			devs:         createDevices(getGpuCount(topology)),
-			socket:       serverSock,
-			resourceName: nvidiaGPUResourceName,
-		},
-	}
-
-	for _, genericDevice := range topology.OtherDevices {
+	devicePlugins := make([]Interface, 0, len(resources))
+	for _, resource := range resources {
 		devicePlugins = append(devicePlugins, &RealNodeDevicePlugin{
-			devs:         createDevices(genericDevice.Count),
-			socket:       path.Join(pluginapi.DevicePluginPath, normalizeDeviceName(genericDevice.Name)+".sock"),
-			resourceName: genericDevice.Name,
+			devs:         createDevices(resource.Count),
+			socket:       resourceSocket(resource.Name),
+			resourceName: resource.Name,
+			stop:         make(chan interface{}),
+			health:       make(chan *pluginapi.Device),
 		})
 	}
 
 	return devicePlugins
+}
+
+func CleanupStaleSockets() error {
+	sockets, err := filepath.Glob(path.Join(pluginapi.DevicePluginPath, "fake-*.sock"))
+	if err != nil {
+		return err
+	}
+
+	for _, socket := range sockets {
+		if err := os.Remove(socket); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceSocket(resourceName string) string {
+	if resourceName == nvidiaGPUResourceName {
+		return serverSock
+	}
+	return path.Join(pluginapi.DevicePluginPath, "fake-"+normalizeDeviceName(resourceName)+".sock")
 }
 
 func normalizeDeviceName(deviceName string) string {

--- a/internal/deviceplugin/device_plugin_test.go
+++ b/internal/deviceplugin/device_plugin_test.go
@@ -64,6 +64,94 @@ var _ = Describe("NewDevicePlugins", func() {
 			Expect(devicePlugins).To(HaveLen(3))
 			Expect(devicePlugins[0]).To(BeAssignableToTypeOf(&RealNodeDevicePlugin{}))
 		})
+
+		It("should return MIG device plugins for mixed MIG topology", func() {
+			topology := &topology.NodeTopology{
+				MigStrategy: "mixed",
+				Gpus: []topology.GpuDetails{
+					{
+						ID:         "GPU-0",
+						MigEnabled: true,
+						MigInstances: []topology.MigInstance{
+							{Profile: "1g.5gb"},
+							{Profile: "1g.5gb"},
+						},
+					},
+				},
+			}
+			kubeClient := &fake.Clientset{}
+			devicePlugins := NewDevicePlugins(topology, kubeClient)
+			Expect(devicePlugins).To(HaveLen(1))
+
+			plugin, ok := devicePlugins[0].(*RealNodeDevicePlugin)
+			Expect(ok).To(BeTrue())
+			Expect(plugin.resourceName).To(Equal("nvidia.com/mig-1g.5gb"))
+			Expect(plugin.devs).To(HaveLen(2))
+		})
+
+		It("should return one device plugin per MIG profile", func() {
+			topology := &topology.NodeTopology{
+				MigStrategy: "mixed",
+				Gpus: []topology.GpuDetails{
+					{
+						ID:         "GPU-0",
+						MigEnabled: true,
+						MigInstances: []topology.MigInstance{
+							{Profile: "1g.5gb"},
+							{Profile: "2g.10gb"},
+						},
+					},
+				},
+			}
+			kubeClient := &fake.Clientset{}
+			devicePlugins := NewDevicePlugins(topology, kubeClient)
+			Expect(devicePlugins).To(HaveLen(2))
+
+			mig1g, ok := devicePlugins[0].(*RealNodeDevicePlugin)
+			Expect(ok).To(BeTrue())
+			Expect(mig1g.resourceName).To(Equal("nvidia.com/mig-1g.5gb"))
+
+			mig2g, ok := devicePlugins[1].(*RealNodeDevicePlugin)
+			Expect(ok).To(BeTrue())
+			Expect(mig2g.resourceName).To(Equal("nvidia.com/mig-2g.10gb"))
+		})
+
+		It("should keep full GPUs alongside MIG profiles in mixed mode", func() {
+			topology := &topology.NodeTopology{
+				MigStrategy: "mixed",
+				Gpus: []topology.GpuDetails{
+					{
+						ID:         "GPU-0",
+						MigEnabled: true,
+						MigInstances: []topology.MigInstance{
+							{Profile: "1g.5gb"},
+						},
+					},
+					{ID: "GPU-1"},
+				},
+			}
+			kubeClient := &fake.Clientset{}
+			devicePlugins := NewDevicePlugins(topology, kubeClient)
+			Expect(devicePlugins).To(HaveLen(2))
+
+			gpuPlugin, ok := devicePlugins[0].(*RealNodeDevicePlugin)
+			Expect(ok).To(BeTrue())
+			Expect(gpuPlugin.resourceName).To(Equal("nvidia.com/gpu"))
+
+			migPlugin, ok := devicePlugins[1].(*RealNodeDevicePlugin)
+			Expect(ok).To(BeTrue())
+			Expect(migPlugin.resourceName).To(Equal("nvidia.com/mig-1g.5gb"))
+		})
 	})
 
+})
+
+var _ = Describe("resourceSocket", func() {
+	It("uses the legacy socket path for nvidia.com/gpu", func() {
+		Expect(resourceSocket("nvidia.com/gpu")).To(Equal(serverSock))
+	})
+
+	It("uses a fake-prefixed socket for MIG resources", func() {
+		Expect(resourceSocket("nvidia.com/mig-1g.5gb")).To(ContainSubstring("fake-nvidia_com_mig_1g_5gb.sock"))
+	})
 })

--- a/internal/deviceplugin/fake_node.go
+++ b/internal/deviceplugin/fake_node.go
@@ -16,22 +16,17 @@ import (
 )
 
 type FakeNodeDevicePlugin struct {
-	kubeClient   kubernetes.Interface
-	gpuCount     int
-	otherDevices map[string]int
+	kubeClient kubernetes.Interface
+	resources  map[string]int
 }
 
 func (f *FakeNodeDevicePlugin) Serve() error {
 	nodeStatus := v1.NodeStatus{
-		Capacity: v1.ResourceList{
-			v1.ResourceName(nvidiaGPUResourceName): *resource.NewQuantity(int64(f.gpuCount), resource.DecimalSI),
-		},
-		Allocatable: v1.ResourceList{
-			v1.ResourceName(nvidiaGPUResourceName): *resource.NewQuantity(int64(f.gpuCount), resource.DecimalSI),
-		},
+		Capacity:    v1.ResourceList{},
+		Allocatable: v1.ResourceList{},
 	}
 
-	for deviceName, count := range f.otherDevices {
+	for deviceName, count := range f.resources {
 		nodeStatus.Capacity[v1.ResourceName(deviceName)] = *resource.NewQuantity(int64(count), resource.DecimalSI)
 		nodeStatus.Allocatable[v1.ResourceName(deviceName)] = *resource.NewQuantity(int64(count), resource.DecimalSI)
 	}

--- a/internal/deviceplugin/fake_node_test.go
+++ b/internal/deviceplugin/fake_node_test.go
@@ -25,9 +25,11 @@ var _ = Describe("FakeNodeDevicePlugin.Serve", func() {
 		fakeClient := fake.NewSimpleClientset(node)
 
 		fakeNodeDevicePlugin := &FakeNodeDevicePlugin{
-			kubeClient:   fakeClient,
-			gpuCount:     1,
-			otherDevices: map[string]int{"device1": 2},
+			kubeClient: fakeClient,
+			resources: map[string]int{
+				nvidiaGPUResourceName: 1,
+				"device1":             2,
+			},
 		}
 
 		err = fakeNodeDevicePlugin.Serve()

--- a/internal/deviceplugin/real_node.go
+++ b/internal/deviceplugin/real_node.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/run-ai/fake-gpu-operator/internal/common/topology"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -31,10 +30,6 @@ type RealNodeDevicePlugin struct {
 	server *grpc.Server
 
 	resourceName string
-}
-
-func getGpuCount(nodeTopology *topology.NodeTopology) int {
-	return len(nodeTopology.Gpus)
 }
 
 func (m *RealNodeDevicePlugin) GetDevicePluginOptions(context.Context, *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {

--- a/internal/kwok-gpu-device-plugin/handlers/configmap/handler.go
+++ b/internal/kwok-gpu-device-plugin/handlers/configmap/handler.go
@@ -50,18 +50,14 @@ func (p *ConfigMapHandler) HandleAdd(cm *v1.ConfigMap) error {
 func (p *ConfigMapHandler) applyFakeDevicePlugin(nodeTopology *topology.NodeTopology, nodeName string) error {
 	nodePatch := &v1.Node{
 		Status: v1.NodeStatus{
-			Capacity: v1.ResourceList{
-				v1.ResourceName(constants.GpuResourceName): *resource.NewQuantity(int64(len(nodeTopology.Gpus)), resource.DecimalSI),
-			},
-			Allocatable: v1.ResourceList{
-				v1.ResourceName(constants.GpuResourceName): *resource.NewQuantity(int64(len(nodeTopology.Gpus)), resource.DecimalSI),
-			},
+			Capacity:    v1.ResourceList{},
+			Allocatable: v1.ResourceList{},
 		},
 	}
 
-	for _, otherDevice := range nodeTopology.OtherDevices {
-		nodePatch.Status.Capacity[v1.ResourceName(otherDevice.Name)] = *resource.NewQuantity(int64(otherDevice.Count), resource.DecimalSI)
-		nodePatch.Status.Allocatable[v1.ResourceName(otherDevice.Name)] = *resource.NewQuantity(int64(otherDevice.Count), resource.DecimalSI)
+	for _, advertisedResource := range topology.AdvertisedResources(nodeTopology) {
+		nodePatch.Status.Capacity[v1.ResourceName(advertisedResource.Name)] = *resource.NewQuantity(int64(advertisedResource.Count), resource.DecimalSI)
+		nodePatch.Status.Allocatable[v1.ResourceName(advertisedResource.Name)] = *resource.NewQuantity(int64(advertisedResource.Count), resource.DecimalSI)
 	}
 
 	patchBytes, err := json.Marshal(nodePatch)

--- a/internal/migfaker/app.go
+++ b/internal/migfaker/app.go
@@ -67,7 +67,7 @@ func (app *MigFakeApp) Init(stop chan struct{}) {
 
 	app.SyncableMigConfig = NewSyncableMigConfig()
 
-	app.MigFaker = NewMigFaker(app.KubeClient)
+	app.MigFaker = NewMigFaker(app.KubeClient, app.KubeClient.ClientSet)
 }
 
 func (app *MigFakeApp) Name() string {

--- a/internal/migfaker/migfaker.go
+++ b/internal/migfaker/migfaker.go
@@ -1,6 +1,7 @@
 package migfaker
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -11,41 +12,42 @@ import (
 	"github.com/google/uuid"
 	"github.com/run-ai/fake-gpu-operator/internal/common/constants"
 	"github.com/run-ai/fake-gpu-operator/internal/common/kubeclient"
+	"github.com/run-ai/fake-gpu-operator/internal/common/topology"
+	"github.com/spf13/viper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 )
 
 var GenerateUuid = uuid.New
 
 type MigFaker struct {
 	kubeclient kubeclient.KubeClientInterface
+	clientset  kubernetes.Interface
 }
 
-func NewMigFaker(kubeclient kubeclient.KubeClientInterface) *MigFaker {
+func NewMigFaker(kubeclient kubeclient.KubeClientInterface, clientset kubernetes.Interface) *MigFaker {
 	return &MigFaker{
 		kubeclient: kubeclient,
+		clientset:  clientset,
 	}
 }
 
 func (faker *MigFaker) FakeMapping(config *MigConfigs) error {
-	mappings := MigMapping{}
-	for _, selectedDevice := range config.SelectedDevices {
-		if len(selectedDevice.Devices) == 0 {
-			continue
-		}
-
-		gpuIdx, err := strconv.Atoi(selectedDevice.Devices[0])
-		if err != nil {
-			return fmt.Errorf("failed to parse gpu index %s: %w", selectedDevice.Devices[0], err)
-		}
-
-		migDeviceMappingInfo, err := faker.getGpuMigDeviceMappingInfo(selectedDevice)
-		if err != nil {
-			return fmt.Errorf("failed to get gpu mig device mapping info: %w", err)
-		}
-
-		mappings[gpuIdx] = migDeviceMappingInfo
+	nodeTopology, err := faker.getNodeTopology()
+	if err != nil {
+		return err
 	}
 
-	smappings, _ := json.Marshal(mappings)
+	mappings, migInstances, err := faker.buildMigState(config, nodeTopology)
+	if err != nil {
+		return err
+	}
+
+	smappings, err := json.Marshal(mappings)
+	if err != nil {
+		return fmt.Errorf("failed to marshal MIG mapping: %w", err)
+	}
 
 	labels := map[string]string{
 		constants.LabelMigConfigState: "success",
@@ -54,7 +56,7 @@ func (faker *MigFaker) FakeMapping(config *MigConfigs) error {
 		constants.AnnotationMigMapping: base64.StdEncoding.EncodeToString(smappings),
 	}
 
-	err := faker.kubeclient.SetNodeLabels(labels)
+	err = faker.kubeclient.SetNodeLabels(labels)
 	if err != nil {
 		log.Printf("error on setting node labels: %e", err)
 		return err
@@ -64,29 +66,166 @@ func (faker *MigFaker) FakeMapping(config *MigConfigs) error {
 		log.Printf("error on setting node annotations: %e", err)
 		return err
 	}
+
+	if err := faker.updateNodeTopology(nodeTopology, migInstances); err != nil {
+		return err
+	}
+
+	if err := faker.restartDevicePluginPod(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func (faker *MigFaker) getGpuMigDeviceMappingInfo(devices SelectedDevices) ([]MigDeviceMappingInfo, error) {
-	gpuProduct, err := faker.getGpuProduct()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get gpu product: %w", err)
+func (faker *MigFaker) buildMigState(config *MigConfigs, nodeTopology *topology.NodeTopology) (MigMapping, map[int][]topology.MigInstance, error) {
+	mappings := MigMapping{}
+	migInstances := map[int][]topology.MigInstance{}
+	gpuProduct := nodeTopology.GpuProduct
+	if gpuProduct == "" {
+		var err error
+		gpuProduct, err = faker.getGpuProduct()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get gpu product: %w", err)
+		}
 	}
 
-	migDevices := []MigDeviceMappingInfo{}
+	for _, selectedDevice := range config.SelectedDevices {
+		if len(selectedDevice.Devices) == 0 {
+			continue
+		}
+
+		gpuIndices, err := expandGPUIndices(selectedDevice.Devices, len(nodeTopology.Gpus))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, gpuIdx := range gpuIndices {
+			mappingInfo, topologyInstances, err := buildGpuMigDeviceState(gpuProduct, selectedDevice)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get gpu mig device mapping info: %w", err)
+			}
+			mappings[gpuIdx] = append(mappings[gpuIdx], mappingInfo...)
+			migInstances[gpuIdx] = append(migInstances[gpuIdx], topologyInstances...)
+		}
+	}
+
+	return mappings, migInstances, nil
+}
+
+func buildGpuMigDeviceState(gpuProduct string, devices SelectedDevices) ([]MigDeviceMappingInfo, []topology.MigInstance, error) {
+	if !devices.MigEnabled {
+		return nil, nil, nil
+	}
+
+	mappingInfo := []MigDeviceMappingInfo{}
+	topologyInstances := []topology.MigInstance{}
 	for _, migDevice := range devices.MigDevices {
 		gpuInstanceId, err := migInstanceNameToGpuInstanceId(gpuProduct, migDevice.Name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get gpu instance id: %w", err)
+			return nil, nil, fmt.Errorf("failed to get gpu instance id: %w", err)
 		}
-		migDevices = append(migDevices, MigDeviceMappingInfo{
+		migUUID := fmt.Sprintf("MIG-%s", GenerateUuid())
+		mappingInfo = append(mappingInfo, MigDeviceMappingInfo{
 			Position:      migDevice.Position,
-			DeviceUUID:    fmt.Sprintf("MIG-%s", GenerateUuid()),
+			DeviceUUID:    migUUID,
 			GpuInstanceId: gpuInstanceId,
+		})
+		topologyInstances = append(topologyInstances, topology.MigInstance{
+			Profile: migDevice.Name,
+			Index:   migDevice.Position,
+			UUID:    migUUID,
+			Status: topology.GpuStatus{
+				PodGpuUsageStatus: topology.PodGpuUsageStatusMap{},
+			},
 		})
 	}
 
-	return migDevices, nil
+	return mappingInfo, topologyInstances, nil
+}
+
+func expandGPUIndices(devices []string, gpuCount int) ([]int, error) {
+	gpuIndices := []int{}
+	seen := map[int]bool{}
+
+	for _, device := range devices {
+		if device == "all" {
+			for idx := 0; idx < gpuCount; idx++ {
+				if !seen[idx] {
+					gpuIndices = append(gpuIndices, idx)
+					seen[idx] = true
+				}
+			}
+			continue
+		}
+
+		gpuIdx, err := strconv.Atoi(device)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse gpu index %s: %w", device, err)
+		}
+		if gpuIdx < 0 || gpuIdx >= gpuCount {
+			return nil, fmt.Errorf("gpu index %d out of range for %d GPUs", gpuIdx, gpuCount)
+		}
+		if !seen[gpuIdx] {
+			gpuIndices = append(gpuIndices, gpuIdx)
+			seen[gpuIdx] = true
+		}
+	}
+
+	return gpuIndices, nil
+}
+
+func (faker *MigFaker) getNodeTopology() (*topology.NodeTopology, error) {
+	if faker.clientset == nil {
+		return nil, fmt.Errorf("kubernetes client is nil")
+	}
+
+	nodeName := viper.GetString(constants.EnvNodeName)
+	nodeTopology, err := topology.GetNodeTopologyFromCM(faker.clientset, nodeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node topology: %w", err)
+	}
+
+	return nodeTopology, nil
+}
+
+func (faker *MigFaker) updateNodeTopology(nodeTopology *topology.NodeTopology, migInstances map[int][]topology.MigInstance) error {
+	for idx := range nodeTopology.Gpus {
+		instances := migInstances[idx]
+		nodeTopology.Gpus[idx].MigEnabled = len(instances) > 0
+		nodeTopology.Gpus[idx].MigInstances = instances
+	}
+
+	nodeName := viper.GetString(constants.EnvNodeName)
+	if err := topology.UpdateNodeTopologyCM(faker.clientset, nodeTopology, nodeName); err != nil {
+		return fmt.Errorf("failed to update node topology: %w", err)
+	}
+
+	return nil
+}
+
+func (faker *MigFaker) restartDevicePluginPod() error {
+	namespace := viper.GetString(constants.EnvTopologyCmNamespace)
+	nodeName := viper.GetString(constants.EnvNodeName)
+	selector := labels.Set{"app": "device-plugin", "component": "device-plugin"}.String()
+	pods, err := faker.clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list device-plugin pods: %w", err)
+	}
+
+	for _, pod := range pods.Items {
+		if pod.Spec.NodeName != nodeName {
+			continue
+		}
+		log.Printf("Deleting device-plugin pod %s/%s to reload MIG resources", namespace, pod.Name)
+		if err := faker.clientset.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("failed to delete device-plugin pod %s/%s: %w", namespace, pod.Name, err)
+		}
+	}
+
+	return nil
 }
 
 func (faker *MigFaker) getGpuProduct() (string, error) {

--- a/internal/migfaker/migfaker_test.go
+++ b/internal/migfaker/migfaker_test.go
@@ -1,6 +1,7 @@
 package migfaker_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -10,11 +11,26 @@ import (
 	"github.com/google/uuid"
 	"github.com/run-ai/fake-gpu-operator/internal/common/constants"
 	"github.com/run-ai/fake-gpu-operator/internal/common/kubeclient"
+	"github.com/run-ai/fake-gpu-operator/internal/common/topology"
 	"github.com/run-ai/fake-gpu-operator/internal/migfaker"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestFakeMapping(t *testing.T) {
+	viper.Set(constants.EnvNodeName, "node1")
+	viper.Set(constants.EnvTopologyCmName, "topology")
+	viper.Set(constants.EnvTopologyCmNamespace, "gpu-operator")
+	oldGenerateUUID := migfaker.GenerateUuid
+	t.Cleanup(func() {
+		migfaker.GenerateUuid = oldGenerateUUID
+		viper.Reset()
+	})
+
 	uid := uuid.New()
 	migConfig := &migfaker.MigConfigs{
 		SelectedDevices: []migfaker.SelectedDevices{
@@ -32,6 +48,30 @@ func TestFakeMapping(t *testing.T) {
 		},
 	}
 	migfaker.GenerateUuid = func() uuid.UUID { return uid }
+
+	nodeTopology := &topology.NodeTopology{
+		GpuProduct:  "NVIDIA-A100-SXM4-40GB",
+		MigStrategy: "mixed",
+		Gpus: []topology.GpuDetails{
+			{ID: "GPU-0"},
+		},
+	}
+	topologyCM, _, err := topology.ToNodeTopologyCM(nodeTopology, "node1")
+	assert.NoError(t, err)
+
+	devicePluginPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "device-plugin-abc",
+			Namespace: "gpu-operator",
+			Labels: map[string]string{
+				"app":       "device-plugin",
+				"component": "device-plugin",
+			},
+		},
+		Spec: v1.PodSpec{NodeName: "node1"},
+	}
+	clientset := fake.NewSimpleClientset(topologyCM, devicePluginPod)
+
 	kubeClientMock := &kubeclient.KubeClientMock{}
 	kubeClientMock.ActualSetNodeLabels = func(labels map[string]string) {
 		assert.Equal(t, labels["nvidia.com/mig.config.state"], "success")
@@ -61,9 +101,82 @@ func TestFakeMapping(t *testing.T) {
 		assert.JSONEq(t, string(expectedMappingJson), string(actualMappingJson))
 	}
 
-	migFaker := migfaker.NewMigFaker(kubeClientMock)
-	err := migFaker.FakeMapping(migConfig)
+	migFaker := migfaker.NewMigFaker(kubeClientMock, clientset)
+	err = migFaker.FakeMapping(migConfig)
 	if err != nil {
 		t.Errorf("Failed to fake mapping %s", err)
 	}
+
+	updatedCM, err := clientset.CoreV1().ConfigMaps("gpu-operator").Get(context.TODO(), topology.GetNodeTopologyCMName("node1"), metav1.GetOptions{})
+	assert.NoError(t, err)
+	updatedTopology, err := topology.FromNodeTopologyCM(updatedCM)
+	assert.NoError(t, err)
+	assert.True(t, updatedTopology.Gpus[0].MigEnabled)
+	assert.Len(t, updatedTopology.Gpus[0].MigInstances, 1)
+	assert.Equal(t, "4g.20gb", updatedTopology.Gpus[0].MigInstances[0].Profile)
+	assert.Equal(t, 0, updatedTopology.Gpus[0].MigInstances[0].Index)
+	assert.Equal(t, fmt.Sprintf("MIG-%s", uid), updatedTopology.Gpus[0].MigInstances[0].UUID)
+
+	_, err = clientset.CoreV1().Pods("gpu-operator").Get(context.TODO(), "device-plugin-abc", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestFakeMappingAllDevicesCreatesUniqueMigInstancesPerGpu(t *testing.T) {
+	viper.Set(constants.EnvNodeName, "node1")
+	viper.Set(constants.EnvTopologyCmName, "topology")
+	viper.Set(constants.EnvTopologyCmNamespace, "gpu-operator")
+	uuids := []uuid.UUID{uuid.New(), uuid.New()}
+	idx := 0
+	oldGenerateUUID := migfaker.GenerateUuid
+	t.Cleanup(func() {
+		migfaker.GenerateUuid = oldGenerateUUID
+		viper.Reset()
+	})
+	migfaker.GenerateUuid = func() uuid.UUID {
+		u := uuids[idx]
+		idx++
+		return u
+	}
+
+	nodeTopology := &topology.NodeTopology{
+		GpuProduct:  "NVIDIA-A100-SXM4-40GB",
+		MigStrategy: "mixed",
+		Gpus: []topology.GpuDetails{
+			{ID: "GPU-0"},
+			{ID: "GPU-1"},
+		},
+	}
+	topologyCM, _, err := topology.ToNodeTopologyCM(nodeTopology, "node1")
+	assert.NoError(t, err)
+	clientset := fake.NewSimpleClientset(topologyCM)
+
+	kubeClientMock := &kubeclient.KubeClientMock{
+		ActualSetNodeLabels: func(labels map[string]string) {
+			assert.Equal(t, "success", labels[constants.LabelMigConfigState])
+		},
+		ActualSetNodeAnnotations: func(annotations map[string]string) {
+			assert.NotEmpty(t, annotations[constants.AnnotationMigMapping])
+		},
+	}
+
+	migFaker := migfaker.NewMigFaker(kubeClientMock, clientset)
+	err = migFaker.FakeMapping(&migfaker.MigConfigs{
+		SelectedDevices: []migfaker.SelectedDevices{
+			{
+				Devices:    []string{"all"},
+				MigEnabled: true,
+				MigDevices: []migfaker.MigDevice{
+					{Name: "1g.5gb", Position: 0, Size: 1},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	updatedCM, err := clientset.CoreV1().ConfigMaps("gpu-operator").Get(context.TODO(), topology.GetNodeTopologyCMName("node1"), metav1.GetOptions{})
+	assert.NoError(t, err)
+	updatedTopology, err := topology.FromNodeTopologyCM(updatedCM)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("MIG-%s", uuids[0]), updatedTopology.Gpus[0].MigInstances[0].UUID)
+	assert.Equal(t, fmt.Sprintf("MIG-%s", uuids[1]), updatedTopology.Gpus[1].MigInstances[0].UUID)
 }

--- a/test/e2e/device-plugin/e2e_test.go
+++ b/test/e2e/device-plugin/e2e_test.go
@@ -1,0 +1,330 @@
+package deviceplugin_e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/run-ai/fake-gpu-operator/internal/common/topology"
+)
+
+const (
+	// Namespace where helm installs everything.
+	releaseNs = "gpu-operator"
+
+	// Node name matches kind-cluster-config.yaml (kind names workers
+	// "<cluster>-worker") and setup.sh's labelling.
+	workerNode = "device-plugin-cluster-worker"
+
+	// gpuCount matches values.yaml's topology.nodePools.mig-pool.gpuCount.
+	gpuCount = 2
+
+	// MIG profile under test (valid for A100-40GB per migfaker's mapping).
+	migProfile  = "1g.5gb"
+	migResource = "nvidia.com/mig-" + migProfile
+
+	// Number of 1g.5gb slices we ask mig-faker to create on GPU 0.
+	migSliceCount = 7
+
+	// A second profile used to exercise reconfiguration (also valid for
+	// A100-40GB). Switching to it must replace the 1g.5gb resources.
+	migProfile2  = "2g.10gb"
+	migResource2 = "nvidia.com/mig-" + migProfile2
+	migSliceCount2 = 3
+
+	gpuResource = "nvidia.com/gpu"
+
+	migConfigAnnotation = "run.ai/mig.config"
+	migStateLabel       = "nvidia.com/mig.config.state"
+
+	eventuallyTimeout = 3 * time.Minute
+	pollInterval      = 3 * time.Second
+)
+
+var (
+	kubeClient kubernetes.Interface
+	restConfig *rest.Config
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Device-Plugin / MIG E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	restConfig, err = getKubeConfig()
+	Expect(err).NotTo(HaveOccurred())
+
+	kubeClient, err = kubernetes.NewForConfig(restConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Sanity: cluster reachable and the MIG worker exists.
+	_, err = kubeClient.CoreV1().Nodes().Get(context.Background(), workerNode, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "MIG worker node %q must exist (set up by setup.sh)", workerNode)
+})
+
+// The specs run in order: verify the plain-GPU baseline, apply a MIG config,
+// then verify mig-faker + device-plugin turn it into nvidia.com/mig-* resources.
+var _ = Describe("mig-faker advertises MIG resources via the device-plugin", Ordered, func() {
+	AfterAll(func() {
+		// Best-effort cleanup so a re-run with SKIP_TEARDOWN=true starts clean:
+		// removing the annotation makes mig-faker clear the MIG state and the
+		// device-plugin returns to advertising whole GPUs.
+		removeNodeAnnotation(workerNode, migConfigAnnotation)
+	})
+
+	It("advertises whole GPUs and no MIG resources before any MIG config", func() {
+		Eventually(func() int64 {
+			return allocatableQuantity(workerNode, gpuResource)
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).
+			Should(Equal(int64(gpuCount)), "node should advertise %d whole GPUs initially", gpuCount)
+
+		Expect(allocatableHas(workerNode, migResource)).To(BeFalse(),
+			"no nvidia.com/mig-* resources should exist before a MIG config is applied")
+	})
+
+	It("accepts a run.ai/mig.config annotation and reports mig.config.state=success", func() {
+		setNodeAnnotation(workerNode, migConfigAnnotation, buildMigConfig(0, migProfile, migSliceCount))
+
+		Eventually(func() string {
+			node, err := kubeClient.CoreV1().Nodes().Get(context.Background(), workerNode, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return node.Labels[migStateLabel]
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).
+			Should(Equal("success"), "mig-faker should set %s=success", migStateLabel)
+	})
+
+	It("writes MigInstances into the per-node topology ConfigMap", func() {
+		Eventually(func(g Gomega) {
+			nodeTopology := getNodeTopology(g, workerNode)
+			g.Expect(nodeTopology.Gpus).To(HaveLen(gpuCount))
+
+			// GPU 0 was selected for MIG.
+			g.Expect(nodeTopology.Gpus[0].MigEnabled).To(BeTrue(), "GPU 0 should be MIG-enabled")
+			g.Expect(nodeTopology.Gpus[0].MigInstances).To(HaveLen(migSliceCount))
+			for _, instance := range nodeTopology.Gpus[0].MigInstances {
+				g.Expect(instance.Profile).To(Equal(migProfile))
+				g.Expect(instance.UUID).To(HavePrefix("MIG-"))
+			}
+
+			// GPU 1 was not selected, so it stays a whole GPU.
+			g.Expect(nodeTopology.Gpus[1].MigEnabled).To(BeFalse(), "GPU 1 should remain a whole GPU")
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).Should(Succeed())
+	})
+
+	It("advertises nvidia.com/mig-<profile> in node allocatable and drops the MIG'd GPU", func() {
+		Eventually(func() int64 {
+			return allocatableQuantity(workerNode, migResource)
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).
+			Should(Equal(int64(migSliceCount)), "node should advertise %d %s", migSliceCount, migResource)
+
+		// One of the two GPUs became MIG, so a single whole GPU remains.
+		Eventually(func() int64 {
+			return allocatableQuantity(workerNode, gpuResource)
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).
+			Should(Equal(int64(gpuCount-1)), "the MIG-enabled GPU should no longer count toward %s", gpuResource)
+	})
+
+	It("schedules a pod that requests the MIG resource", func() {
+		const (
+			ns      = "mig-sched-test"
+			podName = "mig-consumer"
+		)
+		createNamespace(ns)
+		DeferCleanup(func() { deleteNamespace(ns) })
+
+		_, err := kubeClient.CoreV1().Pods(ns).Create(context.Background(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: ns},
+			Spec: corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{{
+					Name:    "ctr0",
+					Image:   "ubuntu:24.04",
+					Command: []string{"bash", "-c", "trap 'exit 0' TERM; sleep 9999 & wait"},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							migResource: resource.MustParse("1"),
+						},
+					},
+				}},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() corev1.PodPhase {
+			pod, err := kubeClient.CoreV1().Pods(ns).Get(context.Background(), podName, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return pod.Status.Phase
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).
+			Should(Equal(corev1.PodRunning), "pod requesting %s should be scheduled and run", migResource)
+	})
+
+	It("replaces the MIG resources when the config changes to a different profile", func() {
+		// Re-annotate GPU 0 with a different profile. mig-faker must rewrite the
+		// topology CM and restart the device-plugin, whose CleanupStaleSockets
+		// removes the old 1g.5gb socket so it no longer lingers in allocatable.
+		setNodeAnnotation(workerNode, migConfigAnnotation, buildMigConfig(0, migProfile2, migSliceCount2))
+
+		Eventually(func(g Gomega) {
+			nodeTopology := getNodeTopology(g, workerNode)
+			g.Expect(nodeTopology.Gpus[0].MigInstances).To(HaveLen(migSliceCount2))
+			g.Expect(nodeTopology.Gpus[0].MigInstances[0].Profile).To(Equal(migProfile2))
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).Should(Succeed())
+
+		// The new profile shows up...
+		Eventually(func() int64 {
+			return allocatableQuantity(workerNode, migResource2)
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).
+			Should(Equal(int64(migSliceCount2)), "node should advertise %d %s after reconfiguration", migSliceCount2, migResource2)
+
+		// ...and the old one is gone (0 or absent), proving stale sockets are cleaned.
+		Eventually(func() int64 {
+			return allocatableQuantity(workerNode, migResource)
+		}).WithTimeout(eventuallyTimeout).WithPolling(pollInterval).
+			Should(BeZero(), "the previous %s resource should no longer be advertised", migResource)
+	})
+})
+
+// migConfigTemplate renders a run.ai/mig.config YAML matching the
+// migfaker.AnnotationMigConfig shape: a single selected GPU with N slices of a
+// profile, positions 0..N-1.
+var migConfigTemplate = template.Must(template.New("migConfig").Parse(
+	`version: v1
+mig-configs:
+  selected:
+  - devices: ["{{ .GpuIndex }}"]
+    mig-enabled: true
+    mig-devices:
+{{- range .Positions }}
+    - name: {{ $.Profile }}
+      position: {{ . }}
+      size: 1
+{{- end }}
+`))
+
+// buildMigConfig enables MIG on a single GPU index with `count` slices of the
+// given profile.
+func buildMigConfig(gpuIndex int, profile string, count int) string {
+	positions := make([]int, count)
+	for i := range positions {
+		positions[i] = i
+	}
+
+	var b strings.Builder
+	err := migConfigTemplate.Execute(&b, struct {
+		GpuIndex  int
+		Profile   string
+		Positions []int
+	}{GpuIndex: gpuIndex, Profile: profile, Positions: positions})
+	Expect(err).NotTo(HaveOccurred())
+	return b.String()
+}
+
+func getNodeTopology(g Gomega, nodeName string) *topology.NodeTopology {
+	cmList, err := kubeClient.CoreV1().ConfigMaps(releaseNs).List(context.Background(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("node-name=%s", nodeName),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cmList.Items).To(HaveLen(1), "expected exactly one topology ConfigMap for %s", nodeName)
+
+	nodeTopology, err := topology.FromNodeTopologyCM(&cmList.Items[0])
+	g.Expect(err).NotTo(HaveOccurred())
+	return nodeTopology
+}
+
+func allocatableQuantity(nodeName, resourceName string) int64 {
+	node, err := kubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return -1
+	}
+	qty, ok := node.Status.Allocatable[corev1.ResourceName(resourceName)]
+	if !ok {
+		return 0
+	}
+	return qty.Value()
+}
+
+func allocatableHas(nodeName, resourceName string) bool {
+	node, err := kubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	_, ok := node.Status.Allocatable[corev1.ResourceName(resourceName)]
+	return ok
+}
+
+func setNodeAnnotation(nodeName, key, value string) {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{key: value},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = kubeClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func removeNodeAnnotation(nodeName, key string) {
+	// A null value in a merge patch deletes the annotation key.
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{key: nil},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	Expect(err).NotTo(HaveOccurred())
+	_, _ = kubeClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+}
+
+func createNamespace(name string) {
+	_, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}, metav1.CreateOptions{})
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func deleteNamespace(name string) {
+	_ = kubeClient.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+func getKubeConfig() (*rest.Config, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		kubeconfig = filepath.Join(home, ".kube", "config")
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("loading kubeconfig from %q: %w", kubeconfig, err)
+	}
+	return cfg, nil
+}

--- a/test/e2e/device-plugin/fixtures/kind-cluster-config.yaml
+++ b/test/e2e/device-plugin/fixtures/kind-cluster-config.yaml
@@ -1,0 +1,19 @@
+# KIND cluster for the device-plugin / mig-faker e2e suite.
+#
+# Unlike the main suite (DRA-based, KWOK nodes) this suite exercises the legacy
+# Kubelet device-plugin path: the device-plugin registers sockets with a REAL
+# kubelet, and mig-faker drives MIG resources onto that node. KWOK nodes have no
+# kubelet, so a real kind worker is required.
+#
+# The worker is dedicated to the MIG/device-plugin path; setup.sh labels it with
+# the pool label plus the MIG-specific labels (nvidia.com/gpu.present and
+# node-role.kubernetes.io/runai-dynamic-mig).
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: device-plugin-cluster
+
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      run.ai/simulated-gpu-node-pool: mig-pool

--- a/test/e2e/device-plugin/fixtures/values.yaml
+++ b/test/e2e/device-plugin/fixtures/values.yaml
@@ -1,0 +1,80 @@
+# E2E values for the device-plugin / mig-faker suite.
+#
+# Enables the legacy Kubelet device-plugin path (mutually exclusive with DRA) so
+# that mig-faker can turn migStrategy: mixed into nvidia.com/mig-<profile>
+# resources in node allocatable.
+
+environment:
+  openshift: false
+  resourceReservationNamespace: runai-reservation
+
+# status-updater creates/maintains the per-node topology ConfigMaps and labels
+# the real node with nvidia.com/gpu.deploy.device-plugin.
+statusUpdater:
+  enabled: true
+  runaiIntegration:
+    enabled: false
+  image:
+    pullPolicy: Never
+
+# topology-server backs nvidia-smi and is a light dependency; keep it on.
+topologyServer:
+  enabled: true
+  image:
+    pullPolicy: Never
+
+# The cluster topology ConfigMap that status-updater reads.
+topologyConfigMap:
+  enabled: true
+
+# The component under test: legacy device-plugin (advertises nvidia.com/gpu and,
+# after mig-faker runs, nvidia.com/mig-<profile>).
+devicePlugin:
+  enabled: true
+  image:
+    pullPolicy: Never
+
+# The component under test: mig-faker.
+migFaker:
+  enabled: true
+  image:
+    pullPolicy: Never
+
+# Everything else off — this suite is intentionally device-plugin-only.
+draPlugin:
+  enabled: false
+
+statusExporter:
+  enabled: false
+
+kwokGpuDevicePlugin:
+  enabled: false
+
+kwokDraPlugin:
+  enabled: false
+
+computeDomainController:
+  enabled: false
+
+computeDomainDraPlugin:
+  enabled: false
+
+kwokComputeDomainDraPlugin:
+  enabled: false
+
+gpuOperator:
+  enabled: false
+
+runtimeClass:
+  enabled: false
+
+# GPU topology: a single MIG-capable A100 pool. migStrategy: mixed means a
+# MIG-enabled GPU is published as its individual nvidia.com/mig-<profile> slices.
+topology:
+  nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+  migStrategy: mixed
+  nodePools:
+    mig-pool:
+      gpuProduct: NVIDIA-A100-SXM4-40GB
+      gpuCount: 2
+      gpuMemory: 40960

--- a/test/e2e/device-plugin/scripts/setup.sh
+++ b/test/e2e/device-plugin/scripts/setup.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# A reference to the directory where this script is located
+SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+PROJECT_ROOT="$(cd -- "${SCRIPTS_DIR}/../../../.." &> /dev/null && pwd)"
+FIXTURES_DIR="$(cd -- "${SCRIPTS_DIR}/../fixtures" &> /dev/null && pwd)"
+
+# --load only works with single-platform builds, so detect the current platform
+CURRENT_PLATFORM="linux/$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
+
+: ${KIND_CLUSTER_NAME:="device-plugin-cluster"}
+: ${VALUES_FILE:="${FIXTURES_DIR}/values.yaml"}
+: ${KIND_CLUSTER_CONFIG_PATH:="${FIXTURES_DIR}/kind-cluster-config.yaml"}
+: ${KIND_K8S_TAG:="v1.34.0"}
+: ${KIND_IMAGE:="kindest/node:${KIND_K8S_TAG}"}
+: ${DOCKER_TAG:="0.0.0-dev"}
+
+# The worker node dedicated to the device-plugin / MIG path. kind names workers
+# "<cluster>-worker".
+WORKER_NODE="${KIND_CLUSTER_NAME}-worker"
+MIG_POOL="mig-pool"
+
+if ! command -v docker &> /dev/null; then
+    echo "Docker not found. Please install Docker."
+    exit 1
+fi
+echo "Docker found in PATH."
+
+if [[ "${SKIP_SETUP:-false}" == "true" ]]; then
+    echo "Skipping setup (SKIP_SETUP=true)"
+    exit 0
+fi
+
+if kind get clusters | grep -q "^${KIND_CLUSTER_NAME}$"; then
+    echo "Cluster ${KIND_CLUSTER_NAME} already exists. Use SKIP_SETUP=true or delete the cluster first."
+    exit 1
+fi
+
+echo "==> Building Docker images (platform ${CURRENT_PLATFORM})..."
+cd "${PROJECT_ROOT}"
+make image DOCKER_TAG="${DOCKER_TAG}" DOCKER_BUILDX_PLATFORMS="${CURRENT_PLATFORM}" DOCKER_BUILDX_PUSH_FLAG="--load"
+
+echo "==> Creating kind cluster ${KIND_CLUSTER_NAME}..."
+kind create cluster \
+    --name "${KIND_CLUSTER_NAME}" \
+    --image "${KIND_IMAGE}" \
+    --config "${KIND_CLUSTER_CONFIG_PATH}" \
+    --wait 2m
+
+echo "==> Loading FGO images into kind..."
+DOCKER_REPO_BASE="${DOCKER_REPO_BASE:-ghcr.io/run-ai/fake-gpu-operator}"
+for component in device-plugin mig-faker status-updater topology-server; do
+    IMAGE="${DOCKER_REPO_BASE}/${component}:${DOCKER_TAG}"
+    echo "    -- ${IMAGE}"
+    kind load docker-image --name "${KIND_CLUSTER_NAME}" "${IMAGE}"
+done
+
+echo "==> Waiting for nodes to be ready..."
+kubectl wait --for=condition=Ready nodes --all --timeout=120s
+
+# Label the worker for the device-plugin + mig-faker DaemonSets. The pool label
+# is already applied via kind config; these are the MIG-specific selectors that
+# would normally come from NFD/GFD on a real GPU node:
+#   - nvidia.com/gpu.present                  -> mig-faker nodeAffinity
+#   - node-role.kubernetes.io/runai-dynamic-mig -> mig-faker nodeSelector
+#   - nvidia.com/gpu.deploy.device-plugin     -> device-plugin nodeSelector
+#     (status-updater also sets this, but set it now to avoid startup crashloops)
+echo "==> Labelling worker ${WORKER_NODE} for the device-plugin / MIG path..."
+kubectl label node "${WORKER_NODE}" \
+    nvidia.com/gpu.present=true \
+    node-role.kubernetes.io/runai-dynamic-mig=true \
+    nvidia.com/gpu.deploy.device-plugin=true \
+    --overwrite
+
+echo "==> Resolving subchart deps..."
+cd "${PROJECT_ROOT}"
+helm dependency update deploy/fake-gpu-operator
+
+echo "==> Installing fake-gpu-operator (device-plugin + mig-faker)..."
+helm upgrade -i fake-gpu-operator deploy/fake-gpu-operator \
+    --namespace gpu-operator \
+    --create-namespace \
+    -f "${VALUES_FILE}" \
+    --set devicePlugin.image.tag="${DOCKER_TAG}" \
+    --set migFaker.image.tag="${DOCKER_TAG}" \
+    --set statusUpdater.image.tag="${DOCKER_TAG}" \
+    --set topologyServer.image.tag="${DOCKER_TAG}" \
+    --wait --timeout 5m
+
+echo "==> Waiting for status-updater pod ready..."
+kubectl wait --for=condition=Ready pod -l app=status-updater -n gpu-operator --timeout=120s
+
+echo "==> Waiting for topology-server pod ready..."
+kubectl wait --for=condition=Ready pod -l app=topology-server -n gpu-operator --timeout=120s
+
+echo "==> Waiting for status-updater to create the topology ConfigMap for ${WORKER_NODE}..."
+for i in {1..30}; do
+    if kubectl get cm -n gpu-operator -l "node-name=${WORKER_NODE}" >/dev/null 2>&1 && \
+       [ -n "$(kubectl get cm -n gpu-operator -l "node-name=${WORKER_NODE}" -o name)" ]; then
+        echo "Topology ConfigMap created for ${WORKER_NODE}!"
+        break
+    fi
+    echo "Waiting for topology ConfigMap... ($i/30)"
+    sleep 2
+done
+
+echo "==> Waiting for device-plugin DaemonSet pod ready..."
+kubectl rollout status daemonset/device-plugin -n gpu-operator --timeout=180s
+
+echo "==> Waiting for mig-faker DaemonSet pod ready..."
+kubectl rollout status daemonset/mig-faker -n gpu-operator --timeout=180s
+
+echo "==> Waiting for nvidia.com/gpu allocatable to populate on ${WORKER_NODE}..."
+DEADLINE=$(( $(date +%s) + 180 ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    GPU_QTY=$(kubectl get node "${WORKER_NODE}" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null || true)
+    if [ -n "${GPU_QTY}" ] && [ "${GPU_QTY}" != "0" ]; then
+        echo "    -- ${WORKER_NODE} reports nvidia.com/gpu=${GPU_QTY}"
+        break
+    fi
+    sleep 3
+done
+
+echo ""
+echo "===================================================="
+echo "Setup complete! Cluster ${KIND_CLUSTER_NAME} is ready."
+echo "  MIG worker: ${WORKER_NODE} (pool: ${MIG_POOL})"
+echo "===================================================="

--- a/test/e2e/device-plugin/scripts/teardown.sh
+++ b/test/e2e/device-plugin/scripts/teardown.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+: ${KIND_CLUSTER_NAME:="device-plugin-cluster"}
+
+if ! command -v docker &> /dev/null; then
+    echo "Docker not found. Please install Docker."
+    exit 1
+fi
+
+if [[ "${SKIP_TEARDOWN:-false}" == "true" ]]; then
+    echo "Skipping teardown (SKIP_TEARDOWN=true)"
+    exit 0
+fi
+
+echo "Deleting kind cluster ${KIND_CLUSTER_NAME}..."
+kind delete cluster --name "${KIND_CLUSTER_NAME}"
+
+echo "Teardown complete!"


### PR DESCRIPTION
## Description

When `migStrategy: mixed` was configured, `mig-faker` faked the MIG hardware metadata (UUIDs, `nvidia.com/mig.config.state: success`) but **no component ever advertised `nvidia.com/mig-*` resources to kubelet** — the `device-plugin` was hardcoded to only register `nvidia.com/gpu`. As a result MIG slices never appeared in `node.status.allocatable` and MIG-based scheduling was impossible.

This PR wires the MIG path end-to-end:

- **Topology is the source of truth for MIG.** `GpuDetails` gains `MigEnabled` + `MigInstances` (`internal/common/topology/types.go`), and a new `topology.AdvertisedResources()` computes the resources a node should expose for `none` / `single` / `mixed` strategies. It's the single place that decides "what does this node advertise," now reused by `device-plugin`, the fake-node plugin, and the KWOK config-map handler.
- **`device-plugin` advertises MIG.** It builds one plugin per advertised resource (each on its own socket), and `CleanupStaleSockets()` removes orphaned sockets on startup so a profile change can't leave stale resources behind.
- **`mig-faker` publishes MIG state.** It writes `MigInstances` into the per-node topology ConfigMap (via `topology.UpdateNodeTopologyCM`, server-side apply — following the repo convention) and restarts the device-plugin pod so kubelet picks up the new allocatable resources. The `devices: [all]` parsing crash is also fixed.
- **RBAC:** `mig-faker` ClusterRole now allows `pods: [list, delete]` (for the restart) and `configmaps: patch` (required by server-side apply).
- **Docs:** README gains a "NVIDIA MIG" section documenting the `migStrategy`, the `node-role.kubernetes.io/runai-dynamic-mig` label, and the `run.ai/mig.config` annotation format — all previously undocumented (called out in #177).

## MIG strategies

`AdvertisedResources` implements all three strategies:

| `migStrategy` | A MIG-enabled GPU sliced into N pieces is advertised as |
|---|---|
| `none` (default) | `nvidia.com/gpu` per physical GPU (MIG ignored) |
| `single` | `nvidia.com/gpu: N` (slices counted as plain GPUs) |
| `mixed` | `nvidia.com/mig-<profile>` per slice; the GPU drops out of `nvidia.com/gpu` |

## Call graph

`mig-faker` (triggered when the `run.ai/mig.config` node annotation changes). The numbered nodes are `FakeMapping`'s steps in execution order; dotted edges are `buildMigState`'s internal helper calls:

```mermaid
flowchart TD
  A["MigFakeApp.Run loop"] -->|annotation change| B["SyncableMigConfig.Get"]
  B --> C["MigFaker.FakeMapping"]
  C --> D["1. getNodeTopology -> topology.GetNodeTopologyFromCM"]
  D --> E["2. buildMigState"]
  E --> F["3. SetNodeLabels: mig.config.state=success"]
  F --> G["4. SetNodeAnnotations: mig-mapping"]
  G --> H["5. updateNodeTopology -> topology.UpdateNodeTopologyCM, SSA patch"]
  H --> I["6. restartDevicePluginPod: list + delete device-plugin pod"]
  E -.-> E1["expandGPUIndices: all / explicit indices"]
  E -.-> E2["buildGpuMigDeviceState -> migInstanceNameToGpuInstanceId"]
```

`device-plugin` (on every (re)start; the restart in step 6 above is what makes it re-read MIG state). Numbered nodes are `main`'s steps in order; dotted edges are `NewDevicePlugins`'s internal calls:

```mermaid
flowchart TD
  M["main"] --> N["1. topology.GetNodeTopologyFromCM"]
  N --> O["2. deviceplugin.CleanupStaleSockets"]
  O --> P["3. deviceplugin.NewDevicePlugins"]
  P --> S["4. plugin.Serve -> Start + Register with kubelet"]
  P -.-> Q["topology.AdvertisedResources: none/single/mixed"]
  P -.-> R["one RealNodeDevicePlugin per advertised resource"]
```

The two processes are decoupled through the per-node topology ConfigMap: `mig-faker` writes MIG state (step 5) and bounces the pod (step 6); the restarted `device-plugin` re-reads the CM (step 1) and `AdvertisedResources` now yields the MIG resources.

## Related Issues

Fixes #177

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`

## Testing

- Unit tests: `AdvertisedResources` strategy matrix (`none` / `single` / `mixed`), device-plugin construction per MIG profile, `resourceSocket`, and `FakeMapping` (including `all` expansion + topology CM update + device-plugin pod restart).
- **New e2e suite** `test/e2e/device-plugin/` (`make e2e-device-plugin`, wired into CI): on a real kind worker it enables the device-plugin + mig-faker, applies a `run.ai/mig.config`, and asserts `nvidia.com/mig-1g.5gb` reaches allocatable, the topology CM is updated, a pod requesting the MIG resource runs, and reconfiguration to a different profile replaces the old resources. Ran locally — 6/6 specs pass. This suite caught the missing `configmaps: patch` RBAC verb.

## Breaking Changes

None.

## Additional Notes

- `device-plugin` and `draPlugin` remain mutually exclusive; the MIG path is device-plugin only, so the new e2e suite is isolated (its own kind cluster) like `e2e-mock`.
- Known limitation: per-MIG-slice _usage_ is not tracked by `status-updater` yet (scheduling works; per-slice metrics/`nvidia-smi` fidelity is a follow-up).
