### PR TITLE
docs(readme): document mixed real + fake GPU nodes (RUN-39914)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- README: "Mixed Real + Fake GPU Nodes" guide for running alongside a real NVIDIA GPU Operator (install in a separate namespace and disable the colliding `devicePlugin`, `statusExporter`, and `runtimeClass` components).
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -391,6 +391,32 @@ kubectl get resourceslices | grep kwok
 kubectl get pod kwok-gpu-pod -o wide
 ```
 
+## 🔀 Mixed Real + Fake GPU Nodes
+
+You can run the Fake GPU Operator **alongside** a real NVIDIA GPU Operator on the same cluster: real-GPU nodes stay fully managed by the real operator, while simulated GPU nodes are added for scale and scheduler testing.
+
+By default the Fake GPU Operator is a drop-in replacement for the real one, so to make them coexist you must (1) install it in its **own namespace** (not `gpu-operator`) and (2) disable the components whose node selectors / cluster-scoped objects collide with the real operator:
+
+```yaml
+# mixed-mode-values.yaml — coexist with a real NVIDIA GPU Operator
+devicePlugin:   { enabled: false }  # selector collides with the real device-plugin on real-GPU nodes
+statusExporter: { enabled: false }  # selector collides with the real dcgm-exporter on real-GPU nodes
+runtimeClass:   { enabled: false }  # cluster-scoped RuntimeClass/nvidia is already owned by the real operator
+```
+
+Install into a dedicated namespace:
+
+```bash
+helm upgrade -i fake-gpu-operator oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator \
+  --namespace fake-gpu-operator --create-namespace \
+  --version <VERSION> -f mixed-mode-values.yaml
+```
+
+Then:
+
+- **Fake GPUs run on KWOK nodes** (see [KWOK Integration](#-kwok-integration-simulated-nodes) above). Their `nvidia.com/gpu` capacity is published by the central `kwok-gpu-device-plugin`, so the disabled per-node DaemonSets aren't needed, and the KWOK `NoSchedule` taint keeps the real operator's DaemonSets off the simulated nodes.
+- **Real-GPU nodes are left untouched** — simply do **not** label them with `run.ai/simulated-gpu-node-pool`. The `status-updater` only acts on nodes carrying that label, so the real operator keeps exclusive ownership of your hardware.
+
 ## 🔍 Troubleshooting
 
 ### Pod Security Admission


### PR DESCRIPTION
## What

Adds a **Mixed Real + Fake GPU Nodes** section to the README explaining how to run the Fake GPU Operator alongside a real NVIDIA GPU Operator on the same cluster.

The Fake GPU Operator is normally a drop-in replacement for the real one, so coexistence requires:
1. Installing it in its **own namespace** (not `gpu-operator`).
2. Disabling the three components whose node selectors / cluster-scoped objects collide with the real operator:
   - `devicePlugin` — DaemonSet selector `nvidia.com/gpu.deploy.device-plugin=true` (real device-plugin's nodes)
   - `statusExporter` — DaemonSet selector `nvidia.com/gpu.deploy.dcgm-exporter=true` (real dcgm-exporter's nodes)
   - `runtimeClass` — cluster-scoped `RuntimeClass/nvidia` already owned by the real operator

Fake GPUs run on KWOK virtual nodes (capacity published by the central `kwok-gpu-device-plugin`); real-GPU nodes are left untouched by simply not labeling them with `run.ai/simulated-gpu-node-pool`.

## Verification

Verified end-to-end on an EKS cluster running the real NVIDIA gpu-operator + Run:AI: a real CUDA pod ran `nvidia-smi` on a real Tesla-T4 node while a fake pod requesting `nvidia.com/gpu` ran on a KWOK node simultaneously, with the real GPU side completely untouched (device-plugin healthy, capacities intact, no fake labels on real nodes).

## Changes
- `README.md`: new "Mixed Real + Fake GPU Nodes" section
- `CHANGELOG.md`: entry under `[Unreleased] → Added`

Docs-only; no code or chart changes.