### PR TITLE
fix(ci): unblock e2e-upgrade latest-main baseline resolution (RUN-40080)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need recent origin/main history for the latest-main lane to walk
-          # back through commits if the newest one's chart hasn't been
-          # published yet (release-helm runs ~5 min after a main merge).
-          fetch-depth: 10
+          # Need recent origin/main history AND tags for the latest-main lane:
+          # it walks first-parent commits to find a published chart, and falls
+          # back to the latest release tag if none is published yet.
+          fetch-depth: 40
+          fetch-tags: true
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -160,11 +161,16 @@ jobs:
             echo "version=${{ matrix.baseline }}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Walk last 5 main commits; first one with a pullable chart wins.
-          # release-helm publishes 0.0.0-<7-char-sha> for every push to main.
-          git fetch origin main --depth=10
+          # release-helm publishes 0.0.0-<7-char-sha> only for first-parent
+          # commits (merge commits / direct pushes to main). Walking every
+          # commit would waste the window on feature-branch commits that a
+          # merge drags into history but that were never published — a single
+          # PR with >=4 commits could fill the whole window with dead SHAs.
+          # So walk --first-parent, and keep the window wide enough to ride out
+          # a streak of in-flight/unpublished commits.
+          git fetch origin main --depth=40
           CHART=oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator
-          for SHA in $(git log origin/main --format='%h' --max-count=5); do
+          for SHA in $(git log origin/main --first-parent --format='%h' --max-count=15); do
             VERSION="0.0.0-${SHA}"
             if helm pull "$CHART" --version "$VERSION" --destination /tmp >/dev/null 2>&1; then
               echo "Resolved latest-main chart: ${VERSION}"
@@ -173,8 +179,19 @@ jobs:
             fi
             echo "  not pullable: ${VERSION}"
           done
-          echo "ERROR: no published chart found for the last 5 main commits."
-          exit 1
+          # No recent main chart published yet — fall back to the latest release
+          # tag instead of failing. This keeps the lane (and the release gate it
+          # blocks via `needs`) from deadlocking when main charts are missing or
+          # in-flight: a hard failure here skips release-helm, which then never
+          # publishes the chart the next run would need.
+          git fetch origin --tags --depth=1 >/dev/null 2>&1 || true
+          LATEST="$(git tag -l 'v*' --sort=-v:refname | sed -n '1s/^v//p')"
+          if [[ -z "$LATEST" ]]; then
+            echo "ERROR: no recent main chart and no release tag to fall back to."
+            exit 1
+          fi
+          echo "No recent main chart published; falling back to latest release: ${LATEST}"
+          echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
       - name: Run helm-upgrade e2e tests
         # Installs the resolved baseline chart, then upgrades to the chart on
         # this branch. Catches the RUN-39195 regression class — templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `device-plugin` injects `NODE_NAME` so non-DRA pods can run the fake `nvidia-smi`. ([#191](https://github.com/run-ai/fake-gpu-operator/issues/191))
+- CI `e2e-upgrade (latest-main)` lane no longer deadlocks resolving its baseline
+  chart. It now walks `--first-parent` main commits (only those publish a
+  `0.0.0-<sha>` chart, so merges no longer fill the window with unpublished
+  feature-branch commits), widens the lookback, and falls back to the latest
+  release tag instead of hard-failing — a hard failure here skipped
+  `release-helm`, which then never published the chart the next run needed.
+  Mirrored in the `make e2e-upgrade-from-main` target. (RUN-40080)
 
 
 ## [0.0.81] - 2026-05-27

--- a/Makefile
+++ b/Makefile
@@ -98,12 +98,14 @@ e2e-upgrade: setup-e2e-upgrade upgrade-e2e-upgrade test-e2e-upgrade teardown-e2e
 .PHONY: e2e-upgrade
 
 # Convenience: run e2e-upgrade with the baseline pinned to the latest
-# pullable chart from origin/main (walks back through the last 5 commits
-# until one is found in the registry). CI does the same via matrix.
+# pullable chart from origin/main. Walks first-parent commits (only those
+# get a published 0.0.0-<sha> chart) and falls back to the latest release
+# tag if none is published yet. CI does the same via matrix.
 e2e-upgrade-from-main:
 	@CHART=oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator; \
-	git fetch origin main >/dev/null 2>&1 || true; \
-	for SHA in $$(git log origin/main --format='%h' --max-count=5); do \
+	git fetch origin main --depth=40 >/dev/null 2>&1 || true; \
+	git fetch origin --tags --depth=1 >/dev/null 2>&1 || true; \
+	for SHA in $$(git log origin/main --first-parent --format='%h' --max-count=15); do \
 		VERSION="0.0.0-$$SHA"; \
 		if helm pull $$CHART --version $$VERSION --destination /tmp >/dev/null 2>&1; then \
 			echo "Using main baseline: $$VERSION"; \
@@ -112,7 +114,10 @@ e2e-upgrade-from-main:
 		fi; \
 		echo "  not pullable: $$VERSION"; \
 	done; \
-	echo "ERROR: no chart found for the last 5 main commits"; exit 1
+	LATEST=$$(git tag -l 'v*' --sort=-v:refname | sed -n '1s/^v//p'); \
+	if [ -z "$$LATEST" ]; then echo "ERROR: no main chart and no release tag to fall back to"; exit 1; fi; \
+	echo "No recent main chart; falling back to latest release: $$LATEST"; \
+	BASELINE_CHART_VERSION=$$LATEST $(MAKE) e2e-upgrade
 .PHONY: e2e-upgrade-from-main
 
 clean:


### PR DESCRIPTION
## Problem

The `e2e-upgrade (latest-main)` CI lane fails at **Resolve baseline chart version** with `ERROR: no published chart found for the last 5 main commits`, turning every PR's CI red. It is already broken on `main` and is **self-perpetuating**.

### Root cause

The resolver picked the baseline chart to upgrade *from* by walking the last **5** main commits and trying `helm pull 0.0.0-<sha>`:

```
for SHA in $(git log origin/main --format='%h' --max-count=5); do ...
```

Two compounding issues:

1. **It counted non-publishable commits.** `release-helm` publishes `0.0.0-<sha>` only for **first-parent** commits (merge commits / direct pushes to main). A merge of a feature branch injects that branch's individual commits into history, and those are never published. The #204 merge brought in 4 feature-branch commits + the merge commit (whose publish was skipped) — exactly filling the 5-slot window with unpullable SHAs:
   ```
   not pullable: 0.0.0-{45e8ac5,83e9699,1a45490,27da5f1,5449a6e} → ERROR
   ```
2. **Deadlock.** `release-docker`/`release-helm` are gated `needs: [..., e2e-upgrade]`. When this lane fails on a push to main, publishing is skipped → that commit's chart is never published → the next PR's window is empty too → it fails again. It can't self-heal.

## Fix

- Walk `git log origin/main --first-parent` so only publishable main tips count.
- Widen the window (`--max-count=15`) and deepen the fetch (`--depth=40`, `fetch-tags`).
- **Fall back to the latest release tag instead of hard-failing.** This is what breaks the deadlock: the lane can no longer fail purely on resolution, so it stops blocking `release-helm`, and main charts keep publishing.
- Mirror the same logic in `make e2e-upgrade-from-main`.

## Validation (run locally against current `origin/main`)

```
not pullable: 0.0.0-45e8ac5      # merge whose publish was skipped
RESOLVED -> 0.0.0-c2a5d72        # first published first-parent commit ✓
fallback LATEST=0.0.81           # release-tag fallback ✓
```
`ci.yml` validates as YAML; `make -n e2e-upgrade-from-main` parses.

## Notes

- Docs-only sibling PR #207 (mixed real+fake nodes) is currently red only because it inherited this exact failure; it should go green once this lands on `main` and republishes a chart.

RUN-40080