### PR TITLE
docs(readme): document the mock backend (fake vs mock) (RUN-40088)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- README: "Mock Backend (Real NVML)" section summarizing the `fake` vs `mock` backends and how to enable mock per pool (links to `docs/mock-backend.md`). (RUN-40088)
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ When requests flow to this inference pod, GPU utilization metrics will reflect t
 - `workloadKind: "InferenceWorkload"` - Single-node inference with Knative metrics
 - `workloadKind: "DistributedWorkload"` - Distributed inference with Knative metrics
 
+## Mock Backend (Real NVML)
+
+Most pools use the **`fake`** backend, where FGO's own device-plugin advertises synthetic `nvidia.com/gpu`.
+
+Switch a pool to the **`mock`** backend to:
+
+- Run the **real upstream NVIDIA gpu-operator** components against simulated GPUs.
+- Support **apps that call NVML directly**, such as `nvidia-smi` or CUDA device discovery.
+
+It installs NVIDIA's [`nvml-mock`](https://github.com/NVIDIA/k8s-test-infra/tree/main/deployments/nvml-mock) on the pool's nodes. It runs privileged pods and writes host files under `/var/lib/nvml-mock`, so it is opt-in per pool:
+
+```yaml
+topology:
+  nodePools:
+    my-mock-pool:
+      gpu:
+        backend: mock
+        profile: a100        # or h100, b200, gb200, l40s, t4
+gpuOperator: { enabled: true }        # device-plugin path; also set gpu-operator.toolkit.enabled
+# nvidiaDraDriver: { enabled: true }  # or use this lighter DRA-only path instead
+```
+
+See **[docs/mock-backend.md](docs/mock-backend.md)** for profiles, caveats such as the cosmetic `ClusterPolicy NotReady` status, and cleanup notes.
+
 ## 🔌 Dynamic Resource Allocation (DRA)
 
 For Kubernetes 1.31+, you can use the DRA plugin instead of the legacy device plugin.


### PR DESCRIPTION
## What

Adds a **🔬 Mock Backend (Real NVML)** section to the main `README.md`, so users discover the `mock` backend (and the `fake` vs `mock` distinction) without first digging into `docs/mock-backend.md`.

The section covers:
- **Concept** — `fake` (default; FGO's device-plugin advertises synthetic `nvidia.com/gpu`, no host mutation) vs `mock` (layers NVIDIA `nvml-mock` so nodes get a real `libnvidia-ml.so` and the *upstream* NVIDIA device-plugin / DRA driver enumerate GPUs through real NVML).
- **When to use which** — short comparison table.
- **Enablement** — per-pool `gpu.backend: mock` + `profile`, plus the consumer-subchart toggles (`gpuOperator.enabled` device-plugin path, or the lighter `nvidiaDraDriver.enabled` DRA path).
- **Caveats** — host writes under `/var/lib/nvml-mock`, don't `--grace-period=0`, cosmetic `ClusterPolicy NotReady` — then links to `docs/mock-backend.md` for the full guide.

Verified the documented schema against the code: `topology.nodePools.<pool>.gpu.backend`/`.profile` (`internal/common/topology/types.go`), and the six built-in profiles (`a100/b200/gb200/h100/l40s/t4`).

## Changes
- `README.md`: new "Mock Backend (Real NVML)" section (~29 lines)
- `CHANGELOG.md`: entry under `[Unreleased] → Added`

Docs-only; no code or chart changes.

RUN-40088