### PR TITLE
fix(nvidia-smi): use nvidia-smi-style failure messages per error path (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `release-helm`, which then never published the chart the next run needed.
   Mirrored in the `make e2e-upgrade-from-main` target. (RUN-40080)
 - Fake `nvidia-smi` exits gracefully instead of panicking on errors. ([#206](https://github.com/run-ai/fake-gpu-operator/issues/206))
+- Fake `nvidia-smi` failure output mirrors real `nvidia-smi` per error instead of one generic line.
 
 
 ## [0.0.81] - 2026-05-27

--- a/cmd/nvidia-smi/main.go
+++ b/cmd/nvidia-smi/main.go
@@ -40,10 +40,10 @@ func main() {
 		fmt.Println("Debug mode enabled")
 	}
 
-	args, errs := getNvidiaSmiArgs()
+	args, summary, errs := getNvidiaSmiArgs()
 
 	if len(args) == 0 {
-		fmt.Println("no devices found")
+		fmt.Println(summary)
 		printErrors(errs)
 		os.Exit(1)
 	}
@@ -58,8 +58,10 @@ func printErrors(errs []error) {
 	}
 }
 
-func getNvidiaSmiArgs() ([]nvidiaSmiArgs, []error) {
-	var errs []error
+// getNvidiaSmiArgs returns the per-GPU rows to render. When no devices can be
+// obtained it returns an empty slice plus a user-facing summary line describing
+// the failure (printed to stdout), with the underlying causes in errs (stderr).
+func getNvidiaSmiArgs() (args []nvidiaSmiArgs, summary string, errs []error) {
 
 	nodeName := os.Getenv(constants.EnvNodeName)
 	if conf.Debug {
@@ -74,7 +76,7 @@ func getNvidiaSmiArgs() ([]nvidiaSmiArgs, []error) {
 	// are fatal: accumulate the error and return no devices.
 	resp, err := http.Get(topologyUrl)
 	if err != nil {
-		return nil, append(errs, fmt.Errorf("fetching topology from %s: %w", topologyUrl, err))
+		return nil, "NVIDIA-SMI has failed because it couldn't communicate with the topology server.", append(errs, fmt.Errorf("fetching topology from %s: %w", topologyUrl, err))
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -84,12 +86,12 @@ func getNvidiaSmiArgs() ([]nvidiaSmiArgs, []error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, append(errs, fmt.Errorf("topology server %s returned %s: %s", topologyUrl, resp.Status, strings.TrimSpace(string(body))))
+		return nil, "No devices were found", append(errs, fmt.Errorf("topology server %s returned %s: %s", topologyUrl, resp.Status, strings.TrimSpace(string(body))))
 	}
 
 	var nodeTopology topology.NodeTopology
 	if err := json.NewDecoder(resp.Body).Decode(&nodeTopology); err != nil {
-		return nil, append(errs, fmt.Errorf("decoding topology from %s: %w", topologyUrl, err))
+		return nil, "Failed to parse devices data", append(errs, fmt.Errorf("decoding topology from %s: %w", topologyUrl, err))
 	}
 	if conf.Debug {
 		fmt.Printf("Received topology: %+v\n", nodeTopology)
@@ -160,7 +162,7 @@ func getNvidiaSmiArgs() ([]nvidiaSmiArgs, []error) {
 		})
 	}
 
-	return allArgs, errs
+	return allArgs, "", errs
 }
 
 func readProcessName() (string, error) {


### PR DESCRIPTION
## What

Follow-up to the graceful error-handling change (#210). Instead of printing a single `no devices found` line for every fatal path, the fake `nvidia-smi` now prints a message that mirrors real `nvidia-smi` for the situation:

| Failure | stdout | exit |
|---------|--------|------|
| topology server unreachable | `NVIDIA-SMI has failed because it couldn't communicate with the topology server.` | 1 |
| topology server returns non-2xx (node unknown) | `No devices were found` | 1 |
| topology body fails to decode | `Failed to parse devices data` | 1 |

`getNvidiaSmiArgs` now returns the user-facing summary line alongside the accumulated errors. The underlying cause is still written to **stderr** for debugging, and the exit code stays **1** (unchanged).

## Verification

Drove each path through a local proxy (Go's `http.Get` honors `HTTP_PROXY`) against the built binary:

```
[A unreachable] stdout: NVIDIA-SMI has failed because it couldn't communicate with the topology server.
                stderr: fetching topology from ...: proxyconnect ... connection refused      exit 1
[B0 404]        stdout: No devices were found
                stderr: topology server ... returned 404 Not Found: 404 page not found        exit 1
[B bad JSON]    stdout: Failed to parse devices data
                stderr: decoding topology from ...: invalid character 'C' ...                  exit 1
```

Non-fatal paths (bad `RUNAI_NUM_OF_GPUS`, missing process name) are unchanged — table still renders, warning to stderr, exit 0. `go build` + `go vet` pass.

Same ticket as #210: [RUN-39984](https://runai.atlassian.net/browse/RUN-39984) / #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RUN-39984]: https://runai.atlassian.net/browse/RUN-39984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ