### PR TITLE
docs(changelog): release v0.0.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+
+## [0.0.82] - 2026-06-04
+
+### Added
+
 - README: "Mock Backend (Real NVML)" section summarizing the `fake` vs `mock` backends and how to enable mock per pool (links to `docs/mock-backend.md`). (RUN-40088)
 - README: "Mixed Real + Fake GPU Nodes" guide for running alongside a real NVIDIA GPU Operator (install in a separate namespace and disable the colliding `devicePlugin`, `statusExporter`, and `runtimeClass` components).
 


### PR DESCRIPTION
## Summary

Promotes the current `[Unreleased]` section into a new `[0.0.82] - 2026-06-04` section, leaving an empty `[Unreleased]` scaffold for the next cycle.

**Release preparation only** — no code changes, just `CHANGELOG.md`. After this merges, cut the release by tagging the resulting main commit:

```bash
git checkout main && git pull
git tag v0.0.82
git push origin v0.0.82
```

The tag push triggers `release-docker` (11 component images at `:0.0.82`, multi-arch) and `release-helm` (chart at `oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator:0.0.82`).

## What's in v0.0.82

Aggregates merged work since v0.0.81:

- **RUN-40173** — Built-in GPU profiles re-synced from NVIDIA/k8s-test-infra `main` (`497fa04`): each profile now carries a `pcie_topology` block (PCI root complexes + per-device `numa_node`), and a `gb300` profile is added. `hack/sync-profiles.sh` source bumped `v0.1.0` → `main` (now resolves tag/branch/SHA) + version-parse fix.
- **RUN-40088** — README "Mock Backend (Real NVML)" section (`fake` vs `mock`).
- **RUN-39914** — README "Mixed Real + Fake GPU Nodes" guide.
- **RUN-40080** — CI `e2e-upgrade (latest-main)` baseline resolution no longer deadlocks (walks `--first-parent`, widens lookback, falls back to latest release tag); mirrored in `make e2e-upgrade-from-main`.
- **#191 (RUN-39004)** — `device-plugin` injects `NODE_NAME` so non-DRA pods can run the fake `nvidia-smi`.
- **#206 (RUN-39984)** — fake `nvidia-smi` exits gracefully instead of panicking; failure output mirrors real `nvidia-smi` per error path.

## Test plan

- [x] Branched off `origin/main`; diff is only the CHANGELOG promotion (9-line insertion)
- [x] `[Unreleased]` left as empty scaffold; all entries moved verbatim under `[0.0.82]`
- [ ] Merge to main, then tag `v0.0.82` to publish