### PR TITLE
fix(ci): drop fetch-tags from e2e-upgrade checkout — broke tag-push releases (RUN-40080)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need recent origin/main history AND tags for the latest-main lane:
-          # it walks first-parent commits to find a published chart, and falls
-          # back to the latest release tag if none is published yet.
+          # Need recent origin/main history for the latest-main lane (it walks
+          # first-parent commits to find a published chart). Tags are fetched
+          # by the resolve step's own `git fetch origin --tags`, NOT here:
+          # fetch-tags:true breaks on tag-push runs (the release trigger) because
+          # checkout then fetches both the commit and refs/tags/<tag> into the
+          # same ref -> "fatal: Cannot fetch both <sha> and refs/tags/<tag>".
           fetch-depth: 40
-          fetch-tags: true
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- CI `e2e-upgrade` checkout no longer fails on tag-push (release) runs. The
+  `fetch-tags: true` added for the latest-main baseline lookup made
+  `actions/checkout` try to fetch both the release commit and `refs/tags/<tag>`
+  into the same ref (`fatal: Cannot fetch both ...`), which failed both lanes
+  and skipped `release-docker`/`release-helm`. Tags are now fetched by the
+  resolve step instead. (RUN-40080)
+
 
 ## [0.0.82] - 2026-06-04
 


### PR DESCRIPTION
## Problem

The `v0.0.82` release pipeline **failed and never published** the images or chart. Both `e2e-upgrade` lanes died at `actions/checkout` with:

```
fatal: Cannot fetch both 0eed95e... and refs/tags/v0.0.82 to refs/tags/v0.0.82
```

`release-docker` and `release-helm` are `needs`-gated on `e2e-upgrade`, so they were **skipped** → `:0.0.82` images + chart absent from GHCR.

## Root cause

RUN-40080 added `fetch-tags: true` to the `e2e-upgrade` checkout (to help the `latest-main` baseline lookup). On a **tag-push** run (i.e. every release), `actions/checkout` then tries to fetch *both* the release commit *and* `refs/tags/<tag>` into the same ref, which git refuses. It passed on every PR (branch pushes don't have the tag-ref collision) and only breaks on releases — the worst place to find out.

## Fix

Remove `fetch-tags: true` from the checkout (keep `fetch-depth: 40`). The `latest-main` lane's resolve step already runs its own `git fetch origin --tags` for the release-tag fallback, so tag availability is preserved. One-line workflow change + comment explaining why.

## Test plan

- [x] Branch/PR runs are unaffected (no tag-ref collision on branch pushes) — this PR's own CI exercises that
- [ ] After merge: re-cut `v0.0.82` (force-move the tag to the fixed commit) and confirm `release-docker` + `release-helm` succeed and `helm pull ...:0.0.82` works