### PR TITLE
feat: derive per-GPU NUMA from profile pcie_topology into node topology CM (RUN-40241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `status-updater` now records each GPU's NUMA node (`numaNode`) in the per-node
+  topology ConfigMap, derived from the GPU profile's `pcie_topology`. This is the
+  data the device-plugin uses to report GPU NUMA affinity. (RUN-40241)
+
 ### Changed
 
 ### Fixed

--- a/internal/common/profile/profile.go
+++ b/internal/common/profile/profile.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,6 +135,91 @@ func DeviceCount(profile map[string]interface{}) int {
 		return len(devices)
 	}
 	return 0
+}
+
+// PCITopology maps each GPU's device index to its NUMA node, derived from the
+// profile's pcie_topology block. Returns an empty (non-nil) map when the profile
+// has no pcie_topology (older profiles / override-only pools). BDFs are lowercased
+// before matching, since a profile's pcie_topology and devices[].pci.bus_id may
+// differ in case.
+func PCITopology(profile map[string]interface{}) map[int]int {
+	result := map[int]int{}
+	if profile == nil {
+		return result
+	}
+
+	pcie, ok := getMap(profile, "pcie_topology")
+	if !ok {
+		return result
+	}
+	complexes, ok := pcie["root_complexes"].([]interface{})
+	if !ok {
+		return result
+	}
+
+	// bus_id (BDF) -> numa_node
+	bdfToNUMA := map[string]int{}
+	for _, rc := range complexes {
+		rcMap, ok := rc.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		numa, ok := toInt(rcMap["numa_node"])
+		if !ok {
+			continue
+		}
+		devices, ok := rcMap["devices"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, d := range devices {
+			if bdf, ok := d.(string); ok {
+				bdfToNUMA[strings.ToLower(bdf)] = numa
+			}
+		}
+	}
+
+	devices, ok := profile["devices"].([]interface{})
+	if !ok {
+		return result
+	}
+	for _, d := range devices {
+		dMap, ok := d.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		idx, ok := toInt(dMap["index"])
+		if !ok {
+			continue
+		}
+		pci, ok := getMap(dMap, "pci")
+		if !ok {
+			continue
+		}
+		busID, ok := pci["bus_id"].(string)
+		if !ok {
+			continue
+		}
+		if numa, ok := bdfToNUMA[strings.ToLower(busID)]; ok {
+			result[idx] = numa
+		}
+	}
+
+	return result
+}
+
+// toInt coerces an int/int64/float64 (as produced by YAML unmarshaling) to int.
+func toInt(v interface{}) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	default:
+		return 0, false
+	}
 }
 
 // toMiB converts a bytes value (which may be int, int64, or float64 from YAML

--- a/internal/common/profile/profile.go
+++ b/internal/common/profile/profile.go
@@ -137,11 +137,13 @@ func DeviceCount(profile map[string]interface{}) int {
 	return 0
 }
 
-// PCITopology maps each GPU's device index to its NUMA node, derived from the
-// profile's pcie_topology block. Returns an empty (non-nil) map when the profile
-// has no pcie_topology (older profiles / override-only pools). BDFs are lowercased
-// before matching, since a profile's pcie_topology and devices[].pci.bus_id may
-// differ in case.
+// PCITopology maps each GPU's 0-based position in the profile's devices list to
+// its NUMA node, derived from the profile's pcie_topology block. Keys are list
+// positions (not the devices[].index field) to match the positional GPU ordering
+// used downstream (generateGpuDetails and the device-plugin). Returns an empty
+// (non-nil) map when the profile has no pcie_topology (older profiles /
+// override-only pools). BDFs are lowercased before matching, since a profile's
+// pcie_topology and devices[].pci.bus_id may differ in case.
 func PCITopology(profile map[string]interface{}) map[int]int {
 	result := map[int]int{}
 	if profile == nil {
@@ -183,12 +185,8 @@ func PCITopology(profile map[string]interface{}) map[int]int {
 	if !ok {
 		return result
 	}
-	for _, d := range devices {
+	for i, d := range devices {
 		dMap, ok := d.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		idx, ok := toInt(dMap["index"])
 		if !ok {
 			continue
 		}
@@ -201,7 +199,7 @@ func PCITopology(profile map[string]interface{}) map[int]int {
 			continue
 		}
 		if numa, ok := bdfToNUMA[strings.ToLower(busID)]; ok {
-			result[idx] = numa
+			result[i] = numa
 		}
 	}
 

--- a/internal/common/profile/profile_test.go
+++ b/internal/common/profile/profile_test.go
@@ -344,6 +344,28 @@ pcie_topology:
 `,
 			want: map[int]int{0: 0}, // index 1's BDF is not in pcie_topology -> omitted
 		},
+		"keys by list position, not the devices[].index field": {
+			yaml: `
+devices:
+  - index: 7
+    pci:
+      bus_id: "0000:07:00.0"
+  - index: 5
+    pci:
+      bus_id: "0000:87:00.0"
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:07:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:87:00.0"
+`,
+			want: map[int]int{0: 0, 1: 1}, // positions 0,1 used; index fields 7,5 ignored
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/common/profile/profile_test.go
+++ b/internal/common/profile/profile_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoad_ValidProfile(t *testing.T) {
@@ -273,4 +274,86 @@ func TestExtract_MemoryAsInt(t *testing.T) {
 	}
 	spec := Extract(data)
 	assert.Equal(t, 16384, spec.GpuMemory)
+}
+
+func TestPCITopology(t *testing.T) {
+	// Note: devices[].pci.bus_id is UPPERCASE here, pcie_topology devices are
+	// lowercase, to prove case-insensitive matching.
+	const withTopology = `
+devices:
+  - index: 0
+    pci:
+      bus_id: "0000:07:00.0"
+  - index: 1
+    pci:
+      bus_id: "0000:0F:00.0"
+  - index: 2
+    pci:
+      bus_id: "0000:87:00.0"
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:07:00.0"
+        - "0000:0f:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:87:00.0"
+`
+	const noTopology = `
+device_defaults:
+  name: "NVIDIA H100 80GB HBM3"
+devices:
+  - index: 0
+    pci:
+      bus_id: "0000:07:00.0"
+`
+	cases := map[string]struct {
+		yaml string
+		want map[int]int
+	}{
+		"maps each index to its root-complex NUMA (case-insensitive)": {
+			yaml: withTopology,
+			want: map[int]int{0: 0, 1: 0, 2: 1},
+		},
+		"no pcie_topology yields empty map": {
+			yaml: noTopology,
+			want: map[int]int{},
+		},
+		"nil profile yields empty map": {
+			yaml: "",
+			want: map[int]int{},
+		},
+		"device with unmatched BDF is omitted": {
+			yaml: `
+devices:
+  - index: 0
+    pci:
+      bus_id: "0000:07:00.0"
+  - index: 1
+    pci:
+      bus_id: "ffff:ff:00.0"
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:07:00.0"
+`,
+			want: map[int]int{0: 0}, // index 1's BDF is not in pcie_topology -> omitted
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var prof map[string]interface{}
+			if tc.yaml != "" {
+				require.NoError(t, yaml.Unmarshal([]byte(tc.yaml), &prof))
+			}
+			got := PCITopology(prof)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/internal/common/topology/resolve.go
+++ b/internal/common/topology/resolve.go
@@ -15,6 +15,7 @@ type ResolvedPool struct {
 	GpuProduct   string
 	GpuMemory    int // MiB
 	GpuCount     int
+	GpuNUMA      map[int]int // gpu index -> NUMA node from profile pcie_topology; nil = override-only pool, empty = profile without pcie_topology
 	OtherDevices []GenericDevice
 }
 
@@ -63,6 +64,7 @@ func resolveWithProfile(kubeClient kubernetes.Interface, namespace string, pool 
 	resolved.GpuProduct = spec.GpuProduct
 	resolved.GpuMemory = spec.GpuMemory
 	resolved.GpuCount = spec.GpuCount
+	resolved.GpuNUMA = profile.PCITopology(merged)
 
 	return resolved, nil
 }

--- a/internal/common/topology/resolve_test.go
+++ b/internal/common/topology/resolve_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/run-ai/fake-gpu-operator/internal/common/profile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -197,4 +199,43 @@ func TestResolveNodePool_ProfileNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing profile, got nil")
 	}
+}
+
+func TestResolveNodePool_PopulatesGpuNUMA(t *testing.T) {
+	profileData := `
+device_defaults:
+  name: "NVIDIA A100"
+  memory:
+    total_bytes: 85899345920
+devices:
+  - index: 0
+    pci:
+      bus_id: "0000:07:00.0"
+  - index: 1
+    pci:
+      bus_id: "0000:87:00.0"
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:07:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:87:00.0"
+`
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gpu-profile-a100",
+			Namespace: "default",
+		},
+		Data: map[string]string{profile.CmProfileKey: profileData},
+	}
+	client := fake.NewSimpleClientset(cm)
+
+	pool := NodePoolConfig{Gpu: GpuConfig{Backend: "fake", Profile: "a100"}}
+	resolved, err := ResolveNodePool(client, "default", pool)
+	require.NoError(t, err)
+	assert.Equal(t, map[int]int{0: 0, 1: 1}, resolved.GpuNUMA)
 }

--- a/internal/common/topology/types.go
+++ b/internal/common/topology/types.go
@@ -52,8 +52,9 @@ type NodeTopology struct {
 }
 
 type GpuDetails struct {
-	ID     string    `yaml:"id"`
-	Status GpuStatus `yaml:"status"`
+	ID       string    `yaml:"id"`
+	Status   GpuStatus `yaml:"status"`
+	NUMANode *int      `yaml:"numaNode,omitempty"`
 }
 
 type PodGpuUsageStatusMap map[types.UID]GpuUsageStatus

--- a/internal/common/topology/types_test.go
+++ b/internal/common/topology/types_test.go
@@ -1,0 +1,38 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGpuDetails_NUMANodeYAML(t *testing.T) {
+	// nil NUMANode is omitted from YAML
+	out, err := yaml.Marshal(GpuDetails{ID: "g0"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "numaNode")
+
+	// set NUMANode is marshaled and round-trips
+	n := 1
+	out, err = yaml.Marshal(GpuDetails{ID: "g0", NUMANode: &n})
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "numaNode: 1")
+
+	var back GpuDetails
+	require.NoError(t, yaml.Unmarshal(out, &back))
+	require.NotNil(t, back.NUMANode)
+	assert.Equal(t, 1, *back.NUMANode)
+
+	// NUMANode 0 must NOT be omitted (zero is a valid NUMA node; omitempty keys off nil, not value)
+	n0 := 0
+	out0, err := yaml.Marshal(GpuDetails{ID: "g0", NUMANode: &n0})
+	require.NoError(t, err)
+	assert.Contains(t, string(out0), "numaNode: 0")
+
+	var back0 GpuDetails
+	require.NoError(t, yaml.Unmarshal(out0, &back0))
+	require.NotNil(t, back0.NUMANode)
+	assert.Equal(t, 0, *back0.NUMANode)
+}

--- a/internal/status-updater/handlers/node/node_suite_test.go
+++ b/internal/status-updater/handlers/node/node_suite_test.go
@@ -1,0 +1,13 @@
+package node
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Handler Suite")
+}

--- a/internal/status-updater/handlers/node/topology_cm.go
+++ b/internal/status-updater/handlers/node/topology_cm.go
@@ -35,7 +35,7 @@ func (p *NodeHandler) createNodeTopologyCM(node *v1.Node) error {
 	nodeTopology = &topology.NodeTopology{
 		GpuMemory:    resolved.GpuMemory,
 		GpuProduct:   resolved.GpuProduct,
-		Gpus:         generateGpuDetails(resolved.GpuCount, node.Name),
+		Gpus:         generateGpuDetails(resolved.GpuCount, node.Name, resolved.GpuNUMA),
 		MigStrategy:  p.clusterConfig.MigStrategy,
 		OtherDevices: resolved.OtherDevices,
 	}
@@ -48,11 +48,15 @@ func (p *NodeHandler) createNodeTopologyCM(node *v1.Node) error {
 	return nil
 }
 
-func generateGpuDetails(gpuCount int, nodeName string) []topology.GpuDetails {
+func generateGpuDetails(gpuCount int, nodeName string, gpuNUMA map[int]int) []topology.GpuDetails {
 	gpus := make([]topology.GpuDetails, gpuCount)
 	for idx := range gpus {
 		gpus[idx] = topology.GpuDetails{
 			ID: fmt.Sprintf("GPU-%s", uuid.NewSHA1(uuid.Nil, []byte(fmt.Sprintf("%s-%d", nodeName, idx)))),
+		}
+		if numa, ok := gpuNUMA[idx]; ok {
+			n := numa // local copy so &n is stable per iteration
+			gpus[idx].NUMANode = &n
 		}
 	}
 

--- a/internal/status-updater/handlers/node/topology_cm_test.go
+++ b/internal/status-updater/handlers/node/topology_cm_test.go
@@ -1,0 +1,43 @@
+package node
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("generateGpuDetails", func() {
+	const nodeName = "worker-1"
+
+	It("sets NUMANode for indices present in the GpuNUMA map", func() {
+		gpus := generateGpuDetails(4, nodeName, map[int]int{0: 0, 1: 0, 2: 1, 3: 1})
+		Expect(gpus).To(HaveLen(4))
+		for i, want := range []int{0, 0, 1, 1} {
+			Expect(gpus[i].NUMANode).NotTo(BeNil())
+			Expect(*gpus[i].NUMANode).To(Equal(want))
+		}
+	})
+
+	It("leaves NUMANode nil when the GpuNUMA map is nil", func() {
+		gpus := generateGpuDetails(2, nodeName, nil)
+		Expect(gpus).To(HaveLen(2))
+		Expect(gpus[0].NUMANode).To(BeNil())
+		Expect(gpus[1].NUMANode).To(BeNil())
+	})
+
+	It("leaves NUMANode nil for indices absent from a non-nil GpuNUMA map", func() {
+		gpus := generateGpuDetails(4, nodeName, map[int]int{0: 0, 2: 1}) // indices 1 and 3 missing
+		Expect(gpus).To(HaveLen(4))
+		Expect(gpus[0].NUMANode).NotTo(BeNil())
+		Expect(*gpus[0].NUMANode).To(Equal(0))
+		Expect(gpus[1].NUMANode).To(BeNil())
+		Expect(gpus[2].NUMANode).NotTo(BeNil())
+		Expect(*gpus[2].NUMANode).To(Equal(1))
+		Expect(gpus[3].NUMANode).To(BeNil())
+	})
+
+	It("assigns a stable ID independent of NUMA", func() {
+		withNUMA := generateGpuDetails(1, nodeName, map[int]int{0: 1})
+		withoutNUMA := generateGpuDetails(1, nodeName, nil)
+		Expect(withNUMA[0].ID).To(Equal(withoutNUMA[0].ID))
+	})
+})


### PR DESCRIPTION
## Summary

PR 1 of 2 (the **producer**) for surfacing per-GPU NUMA placement on fake-GPU nodes.

The status-updater now derives each GPU's NUMA node from the GPU profile's `pcie_topology` block and records it in the per-node topology ConfigMap (`GpuDetails.NUMANode`). On its own this PR is **inert** — nothing consumes `numaNode` yet; the device-plugin consumer that turns it into `Device.Topology` (so NFD's topology-updater zones the GPUs in `NodeResourceTopology`) is PR 2 (RUN-40242).

## Changes

- `profile.PCITopology(merged)` — maps each GPU's 0-based device-list position to its NUMA node, by matching `devices[].pci.bus_id` against `pcie_topology.root_complexes[].devices[]` (case-insensitive). Returns empty when a profile has no `pcie_topology`.
- `ResolvedPool.GpuNUMA` — populated from `PCITopology` in `resolveWithProfile` (override-only pools stay nil).
- `GpuDetails.NUMANode *int` (`yaml:"numaNode,omitempty"`) — new optional field.
- `generateGpuDetails` writes `NUMANode` into each GPU when the profile provides it.

## Backward compatibility

`numaNode` is an `omitempty` pointer: profiles without `pcie_topology` emit no key, and an older device-plugin ignores the unknown key. No change to existing serialized topology.

## Testing

Unit tests for every new unit (`profile`, `topology`, and the first tests for the `status-updater/handlers/node` package): BDF case-insensitivity, the `numaNode: 0` non-omission round-trip, positional keying (independent of the profile `index` field), and nil/partial `GpuNUMA` maps.
