### PR TITLE
feat: report fake-backend device-plugin per-GPU NUMA in Device.Topology (RUN-40242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `status-updater` now records each GPU's NUMA node (`numaNode`) in the per-node
   topology ConfigMap, derived from the GPU profile's `pcie_topology`. This is the
   data the device-plugin uses to report GPU NUMA affinity. (RUN-40241)
+- Fake-backend device-plugin now reports per-GPU NUMA affinity in `Device.Topology`,
+  clamped to the node's real NUMA count, so NFD's topology-updater places fake GPUs
+  into the correct `NodeResourceTopology` zones on real (non-KWOK) nodes. (RUN-40242)
 
 ### Changed
 

--- a/deploy/fake-gpu-operator/templates/device-plugin/_helpers.tpl
+++ b/deploy/fake-gpu-operator/templates/device-plugin/_helpers.tpl
@@ -51,6 +51,9 @@ containers:
         name: runai-shared-directory              
       - mountPath: /var/lib/kubelet/device-plugins
         name: device-plugin
+      - mountPath: /host-sys-node
+        name: host-sys-node
+        readOnly: true
 dnsPolicy: ClusterFirst
 restartPolicy: Always
 serviceAccountName: nvidia-device-plugin
@@ -74,4 +77,8 @@ volumes:
       path: /var/lib/runai/shared
       type: DirectoryOrCreate
     name: runai-shared-directory
+  - hostPath:
+      path: /sys/devices/system/node
+      type: ""
+    name: host-sys-node
 {{- end }}

--- a/deploy/fake-gpu-operator/templates/device-plugin/_helpers.tpl
+++ b/deploy/fake-gpu-operator/templates/device-plugin/_helpers.tpl
@@ -51,8 +51,8 @@ containers:
         name: runai-shared-directory              
       - mountPath: /var/lib/kubelet/device-plugins
         name: device-plugin
-      - mountPath: /host-sys-node
-        name: host-sys-node
+      - mountPath: /host-sys
+        name: host-sys
         readOnly: true
 dnsPolicy: ClusterFirst
 restartPolicy: Always
@@ -78,7 +78,7 @@ volumes:
       type: DirectoryOrCreate
     name: runai-shared-directory
   - hostPath:
-      path: /sys/devices/system/node
-      type: ""
-    name: host-sys-node
+      path: /sys
+      type: Directory
+    name: host-sys
 {{- end }}

--- a/internal/deviceplugin/device_plugin.go
+++ b/internal/deviceplugin/device_plugin.go
@@ -38,9 +38,11 @@ func NewDevicePlugins(topology *topology.NodeTopology, kubeClient kubernetes.Int
 		}}
 	}
 
+	realNUMA := realNUMACount(sysDevicesSystemNodePath)
+
 	devicePlugins := []Interface{
 		&RealNodeDevicePlugin{
-			devs:         createDevices(getGpuCount(topology)),
+			devs:         createDevices(getGpuCount(topology), topology.Gpus, realNUMA),
 			socket:       serverSock,
 			resourceName: nvidiaGPUResourceName,
 		},
@@ -48,7 +50,7 @@ func NewDevicePlugins(topology *topology.NodeTopology, kubeClient kubernetes.Int
 
 	for _, genericDevice := range topology.OtherDevices {
 		devicePlugins = append(devicePlugins, &RealNodeDevicePlugin{
-			devs:         createDevices(genericDevice.Count),
+			devs:         createDevices(genericDevice.Count, nil, realNUMA),
 			socket:       path.Join(pluginapi.DevicePluginPath, normalizeDeviceName(genericDevice.Name)+".sock"),
 			resourceName: genericDevice.Name,
 		})

--- a/internal/deviceplugin/real_node.go
+++ b/internal/deviceplugin/real_node.go
@@ -22,9 +22,11 @@ import (
 const (
 	serverSock = pluginapi.DevicePluginPath + "fake-nvidia-gpu.sock"
 
-	// sysDevicesSystemNodePath is where the host's /sys/devices/system/node is mounted
-	// read-only into the device-plugin container by the Helm chart (device-plugin DaemonSet).
-	sysDevicesSystemNodePath = "/host-sys-node"
+	// sysDevicesSystemNodePath is the per-NUMA-node sysfs dir, under the host /sys that the
+	// Helm chart mounts read-only at /host-sys. Mounting all of /sys (which always exists)
+	// rather than the leaf node dir lets the device-plugin pod start even when this subpath
+	// is absent (e.g. KIND / non-NUMA sysfs); realNUMACount then falls back to 1.
+	sysDevicesSystemNodePath = "/host-sys/devices/system/node"
 )
 
 var numaNodeDirRe = regexp.MustCompile(`^node[0-9]+$`)

--- a/internal/deviceplugin/real_node.go
+++ b/internal/deviceplugin/real_node.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -20,7 +21,34 @@ import (
 
 const (
 	serverSock = pluginapi.DevicePluginPath + "fake-nvidia-gpu.sock"
+
+	// sysDevicesSystemNodePath is where the host's /sys/devices/system/node is mounted
+	// read-only into the device-plugin container by the Helm chart (device-plugin DaemonSet).
+	sysDevicesSystemNodePath = "/host-sys-node"
 )
+
+var numaNodeDirRe = regexp.MustCompile(`^node[0-9]+$`)
+
+// realNUMACount counts node<N> directories under the given sysfs node path.
+// It returns 1 when the path is missing, unreadable, or contains no node dirs,
+// so NUMA reporting degrades gracefully on nodes without NUMA sysfs.
+func realNUMACount(sysNodePath string) int {
+	entries, err := os.ReadDir(sysNodePath)
+	if err != nil {
+		log.Printf("realNUMACount: cannot read %s, defaulting to 1 NUMA node: %v", sysNodePath, err)
+		return 1
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() && numaNodeDirRe.MatchString(e.Name()) {
+			count++
+		}
+	}
+	if count == 0 {
+		return 1
+	}
+	return count
+}
 
 type RealNodeDevicePlugin struct {
 	pluginapi.UnimplementedDevicePluginServer

--- a/internal/deviceplugin/real_node.go
+++ b/internal/deviceplugin/real_node.go
@@ -93,14 +93,26 @@ func dial(unixSocketPath string, timeout time.Duration) (*grpc.ClientConn, error
 	return c, nil
 }
 
-func createDevices(devCount int) []*pluginapi.Device {
+func createDevices(devCount int, gpus []topology.GpuDetails, realNUMA int) []*pluginapi.Device {
 	var devs []*pluginapi.Device
 	for i := 0; i < devCount; i++ {
 		u, _ := uuid.NewRandom()
-		devs = append(devs, &pluginapi.Device{
+		dev := &pluginapi.Device{
 			ID:     u.String(),
 			Health: pluginapi.Healthy,
-		})
+		}
+		// gpus is nil for non-GPU (OtherDevices) resources, and devCount == len(gpus)
+		// for GPUs by construction, so i < len(gpus) only sets topology for real GPUs.
+		// NUMANode >= 0 skips the sentinel/negative case (e.g. -1 = no NUMA); realNUMA > 0
+		// guards the modulo.
+		if i < len(gpus) && gpus[i].NUMANode != nil && *gpus[i].NUMANode >= 0 && realNUMA > 0 {
+			dev.Topology = &pluginapi.TopologyInfo{
+				Nodes: []*pluginapi.NUMANode{
+					{ID: int64(*gpus[i].NUMANode % realNUMA)},
+				},
+			}
+		}
+		devs = append(devs, dev)
 	}
 	return devs
 }

--- a/internal/deviceplugin/real_node_test.go
+++ b/internal/deviceplugin/real_node_test.go
@@ -2,6 +2,8 @@ package deviceplugin
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,5 +39,27 @@ var _ = Describe("RealNodeDevicePlugin Allocate", func() {
 			ContainerPath: "/bin/nvidia-smi",
 			HostPath:      "/var/lib/runai/bin/nvidia-smi",
 		}))
+	})
+})
+
+var _ = Describe("realNUMACount", func() {
+	It("counts node<N> directories (incl. double-digit) and ignores files and non-node entries", func() {
+		dir := GinkgoT().TempDir()
+		for _, name := range []string{"node0", "node1", "node10", "has_cpu", "online", "power"} {
+			Expect(os.Mkdir(filepath.Join(dir, name), 0o755)).To(Succeed())
+		}
+		// a regular file named like a node dir must NOT be counted (IsDir guard)
+		Expect(os.WriteFile(filepath.Join(dir, "node2"), []byte{}, 0o644)).To(Succeed())
+		Expect(realNUMACount(dir)).To(Equal(3))
+	})
+
+	It("returns 1 when the path is missing", func() {
+		Expect(realNUMACount("/nonexistent/sys/node")).To(Equal(1))
+	})
+
+	It("returns 1 when there are no node directories", func() {
+		dir := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(dir, "online"), 0o755)).To(Succeed())
+		Expect(realNUMACount(dir)).To(Equal(1))
 	})
 })

--- a/internal/deviceplugin/real_node_test.go
+++ b/internal/deviceplugin/real_node_test.go
@@ -11,6 +11,7 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/run-ai/fake-gpu-operator/internal/common/constants"
+	"github.com/run-ai/fake-gpu-operator/internal/common/topology"
 )
 
 var _ = Describe("RealNodeDevicePlugin Allocate", func() {
@@ -61,5 +62,58 @@ var _ = Describe("realNUMACount", func() {
 		dir := GinkgoT().TempDir()
 		Expect(os.Mkdir(filepath.Join(dir, "online"), 0o755)).To(Succeed())
 		Expect(realNUMACount(dir)).To(Equal(1))
+	})
+})
+
+var _ = Describe("createDevices", func() {
+	numa := func(n int) *int { return &n }
+
+	It("clamps profile NUMA onto the real NUMA count and sets Topology per index", func() {
+		gpus := []topology.GpuDetails{
+			{ID: "g0", NUMANode: numa(0)},
+			{ID: "g1", NUMANode: numa(1)},
+			{ID: "g2", NUMANode: numa(1)},
+		}
+		// realNUMA=1 -> every GPU clamps to node 0
+		devs := createDevices(len(gpus), gpus, 1)
+		Expect(devs).To(HaveLen(3))
+		for _, d := range devs {
+			Expect(d.Topology).NotTo(BeNil())
+			Expect(d.Topology.Nodes).To(HaveLen(1))
+			Expect(d.Topology.Nodes[0].ID).To(Equal(int64(0)))
+		}
+
+		// realNUMA=2 -> NUMA preserved
+		devs = createDevices(len(gpus), gpus, 2)
+		Expect(devs[0].Topology.Nodes[0].ID).To(Equal(int64(0)))
+		Expect(devs[1].Topology.Nodes[0].ID).To(Equal(int64(1)))
+		Expect(devs[2].Topology.Nodes[0].ID).To(Equal(int64(1)))
+	})
+
+	It("leaves Topology nil when a GPU has no NUMANode", func() {
+		gpus := []topology.GpuDetails{{ID: "g0"}}
+		devs := createDevices(1, gpus, 2)
+		Expect(devs).To(HaveLen(1))
+		Expect(devs[0].Topology).To(BeNil())
+	})
+
+	It("leaves Topology nil for non-GPU devices (nil gpus slice)", func() {
+		devs := createDevices(2, nil, 2)
+		Expect(devs).To(HaveLen(2))
+		Expect(devs[0].Topology).To(BeNil())
+		Expect(devs[1].Topology).To(BeNil())
+	})
+
+	It("wraps a profile NUMA value >= realNUMA via modulo", func() {
+		gpus := []topology.GpuDetails{{ID: "g0", NUMANode: numa(3)}}
+		devs := createDevices(1, gpus, 2)
+		Expect(devs[0].Topology).NotTo(BeNil())
+		Expect(devs[0].Topology.Nodes[0].ID).To(Equal(int64(1))) // 3 % 2 == 1
+	})
+
+	It("leaves Topology nil for a negative NUMANode sentinel", func() {
+		gpus := []topology.GpuDetails{{ID: "g0", NUMANode: numa(-1)}}
+		devs := createDevices(1, gpus, 2)
+		Expect(devs[0].Topology).To(BeNil())
 	})
 })


### PR DESCRIPTION
## Summary

PR 2 of 2 (the **consumer**) for per-GPU NUMA placement on fake-GPU nodes. **Stacked on #215** (RUN-40241, the producer) — base is `eliranw/RUN-40241-device-plugin-numa-topology-producer`; please merge #215 first (GitHub will retarget this to `main` once it lands).

PR 1 records each GPU's NUMA node in the per-node topology ConfigMap. This PR makes the **fake-backend device-plugin** consume it: it reports each GPU's NUMA node in `pluginapi.Device.Topology`, so the kubelet podresources API exposes it and NFD's topology-updater places the GPUs into the correct `NodeResourceTopology` zones on real (non-KWOK) nodes.

## Changes

- `realNUMACount(sysNodePath)` — counts `node<N>` dirs under a mounted sysfs path; returns 1 (graceful) when the path is missing/unreadable/empty.
- `createDevices(devCount, gpus, realNUMA)` — sets `Device.Topology.Nodes[0].ID = profileNUMA % realNUMACount`, guarded by `NUMANode != nil && NUMANode >= 0 && realNUMA > 0`. The clamp is required: NFD drops any NUMA id not present in the node's `/sys` set, so this keeps every GPU in a real zone. Non-GPU (`OtherDevices`) resources never get topology.
- `NewDevicePlugins` computes `realNUMACount` once on the real-node path and threads it through. The KWOK / `EnvFakeNode` path is untouched.
- Chart: a read-only hostPath mount of `/sys/devices/system/node` at `/host-sys-node` (`type: ""`, so the pod still starts if the path is absent and the Go fallback handles it).

## Scope / non-goals

Real (non-KWOK) nodes only. `cpuManagerPolicy=static` is **not** required for GPU zones (it only governs CPU/memory zones). KWOK nodes (no kubelet/sysfs/topology-updater) and the mock backend (upstream device-plugin, tracked separately) are out of scope.

## Testing

Device-plugin unit tests: `realNUMACount` (multi/double-digit counts, file-vs-dir guard, missing path, no-node-dirs), and `createDevices` (clamp-to-0, NUMA-preserved, modulo wrap for profile NUMA >= realNUMA, negative sentinel, nil-NUMANode, nil-gpus). Chart verified via `helm template` + `helm lint`.
