### PR TITLE
chore(release): 0.0.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.0.83] - 2026-06-16
+
+### Added
+
 - `make chart-render-guard` (`hack/chart-render-guard.sh`) and a matching CI
   job that renders the chart with each top-level value nulled and asserts no
   `nil pointer` render-abort. Runs on every PR and gates the release. Catches
@@ -42,6 +50,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   into the same ref (`fatal: Cannot fetch both ...`), which failed both lanes
   and skipped `release-docker`/`release-helm`. Tags are now fetched by the
   resolve step instead. (RUN-40080)
+- Pinned the `nvml-mock` image to `sha-1706195`. Upstream's rolling `:latest`
+  moved to a v0.2.0 build that broke mock-backend pods (`libnvidia-ml.so` not
+  found, `nvidia-operator-validator` never Ready). (RUN-40242)
 
 
 ## [0.0.82] - 2026-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   into the same ref (`fatal: Cannot fetch both ...`), which failed both lanes
   and skipped `release-docker`/`release-helm`. Tags are now fetched by the
   resolve step instead. (RUN-40080)
-- Pinned the `nvml-mock` image to `sha-1706195`. Upstream's rolling `:latest`
-  moved to a v0.2.0 build that broke mock-backend pods (`libnvidia-ml.so` not
-  found, `nvidia-operator-validator` never Ready). (RUN-40242)
-
 
 ## [0.0.82] - 2026-06-04
 


### PR DESCRIPTION
Promotes `[Unreleased]` → `## [0.0.83] - 2026-06-16`. CHANGELOG-only; CD sets the chart/image version from the release tag.

## 0.0.83 contents
**Added**
- fake-NRT: the **status-exporter** publishes a `NodeResourceTopology` per fake-GPU node when a pool declares `numa` (opt-in, off by default). (RUN-40242)
- `make chart-render-guard` + CI job: renders the chart with each top-level value nulled, asserts no nil-pointer abort. (RUN-40241)

**Fixed**
- Nil-safe top-level chart value access (`(.Values.x).y`) so a null/absent key skips its section instead of failing the whole render. (RUN-40241)
- `e2e-upgrade` checkout no longer fails on tag-push release runs. (RUN-40080)
- Pinned `nvml-mock` to `sha-1706195` — upstream `:latest` rolled to a v0.2.0 build that broke mock-backend pods (`libnvidia-ml.so` not found). (RUN-40242)

## Release
After merge, tag **`v0.0.83`** → CI `release-docker` + `release-helm` publish images + chart at 0.0.83.