### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-## [0.0.83] - 2026-06-16
+## [0.1.0] - 2026-06-16
 
 ### Added
 


### PR DESCRIPTION
Renames the just-merged `## [0.0.83]` CHANGELOG section to `## [0.1.0] - 2026-06-16` — releasing as a **minor** bump (new feature: fake-NRT) rather than a patch. Contents unchanged from #220.

After merge, tag **`v0.1.0`** (CD strips the `v` → publishes images + chart at `0.1.0`).