### PR TITLE
feat: report driver and CUDA version in fake nvidia-smi from config (RUN-40764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- The fake `nvidia-smi` now reports the driver version and CUDA version from the
+  pool's GPU profile (`system.driver_version` / `system.cuda_version`) instead of
+  hardcoded values. Pools without a profile fall back to the previous defaults
+  (`470.129.06` / `11.4`). Plumbed through `NodeTopology`. (RUN-40764)
+
 ### Fixed
 
 ## [0.1.0] - 2026-06-16

--- a/cmd/nvidia-smi/main.go
+++ b/cmd/nvidia-smi/main.go
@@ -18,13 +18,22 @@ import (
 )
 
 type nvidiaSmiArgs struct {
-	GpuProduct  string
-	GpuUsedMem  float32
-	GpuTotalMem int
-	GpuUtil     int
-	GpuIdx      int
-	ProcessName string
+	GpuProduct    string
+	DriverVersion string
+	CudaVersion   string
+	GpuUsedMem    float32
+	GpuTotalMem   int
+	GpuUtil       int
+	GpuIdx        int
+	ProcessName   string
 }
+
+// Fallback versions for pools whose config carries no driver/CUDA version
+// (e.g. old-format topology without a GPU profile).
+const (
+	defaultDriverVersion = "470.129.06"
+	defaultCudaVersion   = "11.4"
+)
 
 type config struct {
 	Debug bool
@@ -145,20 +154,24 @@ func getNvidiaSmiArgs() (args []nvidiaSmiArgs, summary string, errs []error) {
 			fmt.Printf("Found GPU %d allocated to pod %s\n", idx, currentPodName)
 		}
 		allArgs = append(allArgs, nvidiaSmiArgs{
-			GpuProduct:  nodeTopology.GpuProduct,
-			GpuTotalMem: gpuTotalMem,
-			GpuUsedMem:  float32(gpu.Status.PodGpuUsageStatus.FbUsed(nodeTopology.GpuMemory)) * float32(gpuPortion),
-			GpuUtil:     gpu.Status.PodGpuUsageStatus.Utilization(),
-			GpuIdx:      idx,
-			ProcessName: processName,
+			GpuProduct:    nodeTopology.GpuProduct,
+			DriverVersion: nodeTopology.DriverVersion,
+			CudaVersion:   nodeTopology.CudaVersion,
+			GpuTotalMem:   gpuTotalMem,
+			GpuUsedMem:    float32(gpu.Status.PodGpuUsageStatus.FbUsed(nodeTopology.GpuMemory)) * float32(gpuPortion),
+			GpuUtil:       gpu.Status.PodGpuUsageStatus.Utilization(),
+			GpuIdx:        idx,
+			ProcessName:   processName,
 		})
 	}
 
 	if len(allArgs) == 0 {
 		allArgs = append(allArgs, nvidiaSmiArgs{
-			GpuProduct:  nodeTopology.GpuProduct,
-			GpuTotalMem: gpuTotalMem,
-			ProcessName: processName,
+			GpuProduct:    nodeTopology.GpuProduct,
+			DriverVersion: nodeTopology.DriverVersion,
+			CudaVersion:   nodeTopology.CudaVersion,
+			GpuTotalMem:   gpuTotalMem,
+			ProcessName:   processName,
 		})
 	}
 
@@ -189,10 +202,19 @@ func printArgs(allArgs []nvidiaSmiArgs) {
 		fmt.Println("Printing nvidia-smi output")
 	}
 
+	driverVersion := defaultDriverVersion
+	if allArgs[0].DriverVersion != "" {
+		driverVersion = allArgs[0].DriverVersion
+	}
+	cudaVersion := defaultCudaVersion
+	if allArgs[0].CudaVersion != "" {
+		cudaVersion = allArgs[0].CudaVersion
+	}
+
 	fmt.Println(time.Now().Format(time.ANSIC))
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
-	t.SetTitle("NVIDIA-SMI 470.129.06   Driver Version: 470.129.06   CUDA Version: 11.4")
+	t.SetTitle(fmt.Sprintf("NVIDIA-SMI %s   Driver Version: %s   CUDA Version: %s", driverVersion, driverVersion, cudaVersion))
 	t.AppendSeparator()
 	t.AppendRow(table.Row{"GPU  Name        Persistence-M", "Bus-Id        Disp.A", "Volatile Uncorr. ECC"})
 	t.AppendRow(table.Row{"Fan  Temp  Perf  Pwr:Usage/Cap", "        Memory-Usage", "GPU-Util  Compute M."})

--- a/internal/common/topology/resolve.go
+++ b/internal/common/topology/resolve.go
@@ -12,10 +12,12 @@ import (
 // profile resolution (Load → Merge → Extract). Downstream code uses these
 // fields to build NodeTopology ConfigMaps.
 type ResolvedPool struct {
-	GpuProduct   string
-	GpuMemory    int // MiB
-	GpuCount     int
-	OtherDevices []GenericDevice
+	GpuProduct    string
+	GpuMemory     int // MiB
+	GpuCount      int
+	DriverVersion string
+	CudaVersion   string
+	OtherDevices  []GenericDevice
 }
 
 // ResolveNodePool resolves a NodePoolConfig into concrete GPU spec fields.
@@ -63,6 +65,8 @@ func resolveWithProfile(kubeClient kubernetes.Interface, namespace string, pool 
 	resolved.GpuProduct = spec.GpuProduct
 	resolved.GpuMemory = spec.GpuMemory
 	resolved.GpuCount = spec.GpuCount
+	resolved.DriverVersion = spec.DriverVersion
+	resolved.CudaVersion = spec.CudaVersion
 
 	return resolved, nil
 }

--- a/internal/common/topology/resolve_test.go
+++ b/internal/common/topology/resolve_test.go
@@ -63,6 +63,12 @@ devices:
 	if resolved.GpuCount != 8 {
 		t.Errorf("GpuCount = %d, want %d", resolved.GpuCount, 8)
 	}
+	if resolved.DriverVersion != "550.163.01" {
+		t.Errorf("DriverVersion = %q, want %q", resolved.DriverVersion, "550.163.01")
+	}
+	if resolved.CudaVersion != "12.4" {
+		t.Errorf("CudaVersion = %q, want %q", resolved.CudaVersion, "12.4")
+	}
 }
 
 func TestResolveNodePool_WithProfileAndOverrides(t *testing.T) {

--- a/internal/common/topology/types.go
+++ b/internal/common/topology/types.go
@@ -62,11 +62,13 @@ type GpuOperatorConfig struct {
 }
 
 type NodeTopology struct {
-	GpuMemory    int             `yaml:"gpuMemory"`
-	GpuProduct   string          `yaml:"gpuProduct"`
-	Gpus         []GpuDetails    `yaml:"gpus"`
-	MigStrategy  string          `yaml:"migStrategy"`
-	OtherDevices []GenericDevice `yaml:"otherDevices,omitempty"`
+	GpuMemory     int             `yaml:"gpuMemory"`
+	GpuProduct    string          `yaml:"gpuProduct"`
+	DriverVersion string          `yaml:"driverVersion,omitempty"`
+	CudaVersion   string          `yaml:"cudaVersion,omitempty"`
+	Gpus          []GpuDetails    `yaml:"gpus"`
+	MigStrategy   string          `yaml:"migStrategy"`
+	OtherDevices  []GenericDevice `yaml:"otherDevices,omitempty"`
 }
 
 type GpuDetails struct {

--- a/internal/status-updater/handlers/node/topology_cm.go
+++ b/internal/status-updater/handlers/node/topology_cm.go
@@ -33,11 +33,13 @@ func (p *NodeHandler) createNodeTopologyCM(node *v1.Node) error {
 	}
 
 	nodeTopology = &topology.NodeTopology{
-		GpuMemory:    resolved.GpuMemory,
-		GpuProduct:   resolved.GpuProduct,
-		Gpus:         generateGpuDetails(resolved.GpuCount, node.Name),
-		MigStrategy:  p.clusterConfig.MigStrategy,
-		OtherDevices: resolved.OtherDevices,
+		GpuMemory:     resolved.GpuMemory,
+		GpuProduct:    resolved.GpuProduct,
+		DriverVersion: resolved.DriverVersion,
+		CudaVersion:   resolved.CudaVersion,
+		Gpus:          generateGpuDetails(resolved.GpuCount, node.Name),
+		MigStrategy:   p.clusterConfig.MigStrategy,
+		OtherDevices:  resolved.OtherDevices,
 	}
 
 	err = topology.CreateNodeTopologyCM(p.kubeClient, nodeTopology, node)


### PR DESCRIPTION
## What

The fake `nvidia-smi` hardcoded its driver version (`470.129.06`) and CUDA version (`11.4`) in the output title. It now reports them from the pool's GPU profile (`system.driver_version` / `system.cuda_version`).

## Why

The `nvidia-smi` binary only sees `NodeTopology` (fetched over HTTP from the topology-server), so the versions are now plumbed through the existing config resolution chain:

`profile.GpuSpec` → `ResolvedPool` → `NodeTopology` → `cmd/nvidia-smi`

`GpuSpec` already extracted `driver_version`/`cuda_version` (used today by the mock backend's `DRIVER_VERSION` env var) — they were just dropped at `ResolvedPool`/`NodeTopology` because those structs didn't carry the fields.

## Fallback / compatibility

Pools **without** a profile (old-format topology has no version concept) fall back to the previous hardcoded defaults (`470.129.06` / `11.4`), so there's no behavior change for existing configs.

CUDA version is wired alongside driver version since it lives in the same profile `system:` block and the same nvidia-smi title line.

## Other static values

The remaining hardcoded fields in the fake `nvidia-smi` output (Bus-Id, temp `33C`, perf `P8`, power `11W / 70W`, ECC/MIG/persistence) have **no** config source anywhere in the profile/topology and are left as-is.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/common/topology/... ./internal/status-updater/... ./cmd/nvidia-smi/...`
- [x] Added driver/CUDA assertions to `TestResolveNodePool_WithProfile`
