### PR TITLE
feat(openshift-scc-support): grant privileged SCC to all components that need it on OpenShift

### DIFF
--- a/deploy/fake-gpu-operator/templates/compute-domain-dra-plugin/clusterrole.yaml
+++ b/deploy/fake-gpu-operator/templates/compute-domain-dra-plugin/clusterrole.yaml
@@ -29,4 +29,14 @@ rules:
       - create
       - update
       - delete
+{{- if (.Values.environment).openshift }}
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - privileged
+    verbs:
+      - use
+{{- end }}
 {{- end -}}

--- a/deploy/fake-gpu-operator/templates/device-plugin/clusterrole.yaml
+++ b/deploy/fake-gpu-operator/templates/device-plugin/clusterrole.yaml
@@ -16,4 +16,14 @@ rules:
       - nodes/status
     verbs:
       - patch
+{{- if (.Values.environment).openshift }}
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - privileged
+    verbs:
+      - use
+{{- end }}
 {{- end -}}

--- a/deploy/fake-gpu-operator/templates/dra-device-plugin/templates/clusterrole.yaml
+++ b/deploy/fake-gpu-operator/templates/dra-device-plugin/templates/clusterrole.yaml
@@ -14,4 +14,10 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceslices"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- if (.Values.environment).openshift }}
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["privileged"]
+  verbs: ["use"]
+{{- end }}
 {{- end -}}

--- a/deploy/fake-gpu-operator/templates/mig-faker/clusterrole.yaml
+++ b/deploy/fake-gpu-operator/templates/mig-faker/clusterrole.yaml
@@ -22,4 +22,14 @@ rules:
       - update
       - list
       - watch
+{{- if (.Values.environment).openshift }}
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - privileged
+    verbs:
+      - use
+{{- end }}
 {{- end -}}

--- a/test/helm/openshift_scc_test.sh
+++ b/test/helm/openshift_scc_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Helm chart-render assertions for OpenShift SCC support.
+# Verifies that environment.openshift=true adds the privileged SCC rule
+# to all component ClusterRoles that run privileged containers.
+set -euo pipefail
+
+CHART="${CHART:-deploy/fake-gpu-operator}"
+PASS=0
+FAIL=0
+
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+assert_contains() {
+    local label="$1"
+    local pattern="$2"
+    if grep -qE "$pattern" "$TMPFILE"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label  (pattern not found: $pattern)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_absent() {
+    local label="$1"
+    local pattern="$2"
+    if grep -qE "$pattern" "$TMPFILE"; then
+        echo "FAIL: $label  (unexpected match: $pattern)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# Count occurrences of a pattern and assert the expected number.
+assert_count() {
+    local label="$1"
+    local pattern="$2"
+    local expected="$3"
+    local actual
+    actual=$(grep -cE "$pattern" "$TMPFILE" || true)
+    if [ "$actual" -eq "$expected" ]; then
+        echo "PASS: $label (count=$actual)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label  (expected $expected, got $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+render() {
+    helm template fgo "$CHART" "$@" > "$TMPFILE"
+}
+
+SCC_PATTERN="securitycontextconstraints"
+
+echo "=== Case 1: defaults (environment.openshift=false) ==="
+render
+assert_absent "no SCC rules without openshift flag" "$SCC_PATTERN"
+
+echo ""
+echo "=== Case 2: environment.openshift=true, default components ==="
+render --set environment.openshift=true
+# status-exporter already had SCC — now device-plugin and mig-faker should too
+assert_contains "SCC rule present in rendered output" "$SCC_PATTERN"
+# device-plugin + status-exporter + mig-faker + gpu-operator subchart = 4
+assert_count "SCC rule in 4 ClusterRoles" "$SCC_PATTERN" 4
+
+echo ""
+echo "=== Case 3: environment.openshift=true, DRA enabled ==="
+render --set environment.openshift=true \
+       --set draPlugin.enabled=true \
+       --set computeDomainDraPlugin.enabled=true \
+       --namespace gpu-operator
+# device-plugin + status-exporter + mig-faker + dra-plugin + compute-domain-dra + gpu-operator subchart = 6
+assert_count "SCC rule in 6 ClusterRoles" "$SCC_PATTERN" 6
+
+echo ""
+echo "=== Case 4: environment.openshift=true, only device-plugin ==="
+render --set environment.openshift=true \
+       --set statusExporter.enabled=false \
+       --set migFaker.enabled=false
+# device-plugin + gpu-operator subchart = 2
+assert_count "SCC rule in 2 ClusterRoles" "$SCC_PATTERN" 2
+
+echo ""
+echo "--- Results: $PASS passed, $FAIL failed ---"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Description

When `environment.openshift=true`, add the `security.openshift.io` SCC rule to the ClusterRoles for device-plugin, mig-faker, compute-domain-dra-plugin, and dra-plugin-gpu.

The status-exporter already had this rule. Without it, DaemonSets for these components fail with `unable to validate against any security context constraint` on OpenShift because they run privileged containers or mount hostPath volumes.

## Related Issues

Relates #222

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Updated `CHANGELOG.md` under `## [Unreleased]` (or applied `skip-changelog` label)

## Breaking Changes

None. The SCC rules are only rendered when `environment.openshift=true` (default: false).

## Additional Notes

Tested on OpenShift 4.21 (CRC):
- **Without** `environment.openshift=true`: device-plugin and nvidia-dcgm-exporter DaemonSets fail with `FailedCreate: unable to validate against any security context constraint`
- **With** `environment.openshift=true`: all pods start without manual `oc adm policy` commands

Helm template test added at `test/helm/openshift_scc_test.sh` covering all toggle combinations (5/5 pass).

AI tools were used during development of this contribution, specifically to generate file `openshift_scc_test.sh`.