### PR TITLE
fix(topology): carry numa through old-format pool normalization (RUN-41037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- A `numa` block on an old-format (flat `gpuCount`/`gpuProduct`/`gpuMemory`) node
+  pool is no longer silently dropped during normalization, so such pools now get
+  their `NodeResourceTopology` published when
+  `statusExporter.nodeResourceTopology.enabled` is set.
+  ([#229](https://github.com/run-ai/fake-gpu-operator/issues/229))
+
 ## [0.2.0] - 2026-07-01
 
 ### Added

--- a/internal/common/topology/normalize.go
+++ b/internal/common/topology/normalize.go
@@ -47,6 +47,7 @@ func normalizeNodePool(old NodePoolTopology) NodePoolConfig {
 			Backend:   "fake",
 			Overrides: overrides,
 		},
+		Numa: old.Numa,
 	}
 
 	if len(old.OtherDevices) > 0 {

--- a/internal/common/topology/normalize_test.go
+++ b/internal/common/topology/normalize_test.go
@@ -337,3 +337,55 @@ func TestFromClusterConfigCM_MissingKey(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing key")
 }
+
+func TestNormalizeOldFormatPreservesNuma(t *testing.T) {
+	old := &ClusterTopology{
+		NodePoolLabelKey: "run.ai/simulated-gpu-node-pool",
+		NodePools: map[string]NodePoolTopology{
+			"nodepool-0": {
+				GpuCount:   16,
+				GpuMemory:  12000,
+				GpuProduct: "Tesla-V100",
+				Numa: &NumaConfig{
+					Zones:     2,
+					Distances: &NumaDistances{Self: 10, Remote: 21},
+				},
+			},
+		},
+	}
+
+	config := normalizeOldToClusterConfig(old)
+
+	require.Contains(t, config.NodePools, "nodepool-0")
+	pool := config.NodePools["nodepool-0"]
+	require.NotNil(t, pool.Numa, "numa block must survive old-format normalization")
+	assert.Equal(t, 2, pool.Numa.Zones)
+	require.NotNil(t, pool.Numa.Distances)
+	assert.Equal(t, 10, pool.Numa.Distances.Self)
+	assert.Equal(t, 21, pool.Numa.Distances.Remote)
+}
+
+func TestParseOldFormatYAMLPreservesNuma(t *testing.T) {
+	yamlData := `
+nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+nodePools:
+  nodepool-0:
+    gpuCount: 16
+    gpuMemory: 12000
+    gpuProduct: Tesla-V100
+    numa:
+      zones: 2
+      distances:
+        self: 10
+        remote: 21
+`
+	config, err := ParseAndNormalizeTopology([]byte(yamlData))
+	require.NoError(t, err)
+
+	pool := config.NodePools["nodepool-0"]
+	require.NotNil(t, pool.Numa, "numa on an old-format pool must not be silently dropped")
+	assert.Equal(t, 2, pool.Numa.Zones)
+
+	devices := pool.Gpu.Overrides["devices"].([]interface{})
+	assert.Len(t, devices, 16)
+}

--- a/internal/common/topology/types.go
+++ b/internal/common/topology/types.go
@@ -16,6 +16,7 @@ type NodePoolTopology struct {
 	GpuMemory    int             `yaml:"gpuMemory"`
 	GpuProduct   string          `yaml:"gpuProduct"`
 	OtherDevices []GenericDevice `yaml:"otherDevices"`
+	Numa         *NumaConfig     `yaml:"numa,omitempty"`
 }
 
 // ClusterConfig is the new top-level config structure (cluster: key in topology CM).


### PR DESCRIPTION
## What

A `numa:` block on an **old-format** (flat `gpuCount`/`gpuProduct`/`gpuMemory`) node pool was **silently dropped** at parse time — `NodePoolTopology` had no `Numa` field, so `yaml.Unmarshal` discarded the key, normalization produced `Numa == nil`, and the NRT publisher skipped the pool. No error or warning anywhere; no `NodeResourceTopology` was ever created.

Fixes #229.

## Change

- `NodePoolTopology`: add `Numa *NumaConfig \`yaml:"numa,omitempty"\``.
- `normalizeNodePool`: copy `Numa` into the resulting `NodePoolConfig`.

Backward-compatible: pools without `numa` are unchanged (`nil` before and after).

## Tests

- `TestNormalizeOldFormatPreservesNuma` — unit, struct-level normalization.
- `TestParseOldFormatYAMLPreservesNuma` — end-to-end `ParseAndNormalizeTopology` with the exact YAML shape from the field report (old-format pool + numa), asserting numa survives and GPU count still normalizes to 16 devices.
- All existing topology/status-exporter/status-updater suites pass; golangci-lint clean.

Found debugging a live cluster where `nodePools.<name>.numa` was configured in old-format values and no NRT appeared.