### PR TITLE
fix(ci): build and push kwok-compute-domain-dra-plugin image (RUN-41041)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        component: [device-plugin, dra-plugin-gpu, status-updater, kwok-gpu-device-plugin, kwok-dra-plugin, status-exporter, topology-server, mig-faker, jupyter-notebook, compute-domain-controller, compute-domain-dra-plugin]
+        component: [device-plugin, dra-plugin-gpu, status-updater, kwok-gpu-device-plugin, kwok-dra-plugin, kwok-compute-domain-dra-plugin, status-exporter, topology-server, mig-faker, jupyter-notebook, compute-domain-controller, compute-domain-dra-plugin]
     steps:
       - uses: actions/checkout@v4
       - name: Log in to GitHub Container Registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The `kwok-compute-domain-dra-plugin` image is now built and pushed by the
+  release pipeline. It was missing from the CI release matrix, so enabling
+  `kwokComputeDomainDraPlugin.enabled` caused an `ImagePullBackOff`. (RUN-41041)
+
 ## [0.2.0] - 2026-07-01
 
 ### Added


### PR DESCRIPTION
## What

Adds `kwok-compute-domain-dra-plugin` to the `release-docker` CI matrix so the image is actually built and pushed to `ghcr.io`.

## Why

The component was a valid `Dockerfile` target, listed in `Makefile` `COMPONENTS`, and referenced by its Helm deployment — but missing from the hand-maintained `release-docker.strategy.matrix.component` list in `.github/workflows/ci.yml`. So the image was never published, and enabling `kwokComputeDomainDraPlugin.enabled: true` failed with `ImagePullBackOff` on `ghcr.io/run-ai/fake-gpu-operator/kwok-compute-domain-dra-plugin:<tag>`.

## Notes

- `status-exporter-kwok` is also a Dockerfile target absent from the matrix, but it's intentionally not published: the kwok status-exporter deployment reuses the `status-exporter` image (which packs both binaries), so no separate image is needed.

Closes #228