### PR TITLE
docs(podresources): make consumer usage generic, not KAI-npe-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   matching sysfs `cpulist` tree per node, so KAI-Scheduler's numa-placement-exporter
   observes fake GPU/CPU/memory NUMA placement on real nodes. Opt in with
   `statusExporter.podResources.enabled` (off by default); point `npe` at the FGO
-  socket/sysfs paths (see `docs/npe-podresources.md`). (RUN-40987)
+  socket/sysfs paths (see `docs/podresources.md`). (RUN-40987)
 - On OpenShift, the privileged SecurityContextConstraints is now granted to every
   component that needs host access (previously only some). (#225)
 

--- a/docs/podresources.md
+++ b/docs/podresources.md
@@ -1,9 +1,11 @@
-# Fake podresources for KAI NUMA placement (`npe`)
+# Fake kubelet podresources + sysfs for NUMA placement
 
 The status-exporter can serve a **fake kubelet podresources gRPC socket** and a matching
-**sysfs `cpulist` tree** on each fake-GPU node, so KAI-Scheduler's numa-placement-exporter
-(`npe`) observes fake GPU/CPU/memory NUMA placement on real nodes — without real
-multi-socket hardware.
+**sysfs `cpulist` tree** on each fake-GPU node, so any tool that consumes the kubelet
+[podresources API](https://kubernetes.io/docs/concepts/cluster-administration/device-plugins/#monitoring-device-plugin-resources)
+observes fake GPU/CPU/memory NUMA placement on real nodes — without real multi-socket
+hardware. KAI-Scheduler's numa-placement-exporter (`npe`) is one such consumer; see the
+example below.
 
 This is off by default.
 
@@ -17,13 +19,8 @@ For every pod that holds fake GPUs on a node, the status-exporter synthesizes a 
   single NUMA node).
 - **CPU and memory** are charged to those zones in proportion to the pod's per-zone GPU count,
   from the pod's resource *requests*.
-- The **sysfs `cpulist`** tree (`devices/system/node/node<N>/cpulist`) lets `npe` resolve
+- The **sysfs `cpulist`** tree (`devices/system/node/node<N>/cpulist`) lets a consumer resolve
   CPU-id → NUMA node, since the podresources API carries CPU ids without topology.
-
-`npe` reads these, writes the `kai.scheduler/numa-placement-observed` annotation on each pod,
-and the KAI scheduler's `numa` plugin (running with its default `reconstructAvailable=true`)
-reconstructs per-zone availability from those observed placements. Live `NodeResourceTopology`
-`available` is therefore **not** required on this path.
 
 ## Enable it
 
@@ -46,21 +43,29 @@ to avoid colliding with the real kubelet):
 
 Both are backed by `hostPath` volumes (`DirectoryOrCreate`) on the node.
 
-## Point `npe` at the FGO paths
+## Point a consumer at the FGO paths
 
-Configure the KAI numa-placement-exporter to read the FGO socket and sysfs tree instead of the
-real kubelet's, and confine it to the fake-GPU nodes:
+Any podresources client points at the FGO socket and sysfs tree instead of the real kubelet's,
+and is scoped to the fake-GPU nodes (e.g. via a `nodeSelector`):
+
+- podresources socket: `/var/lib/fake-gpu-operator/pod-resources/kubelet.sock`
+- sysfs root: `/var/lib/fake-gpu-operator/sys` — mount it into the consumer container with a
+  `hostPath` volume and point the consumer's sysfs-root at the mount path
+
+## Example: KAI numa-placement-exporter (`npe`)
+
+Configure `npe` to read the FGO socket and sysfs tree, and confine it to the fake-GPU nodes:
 
 - `--podresources-socket=/var/lib/fake-gpu-operator/pod-resources/kubelet.sock`
 - `--sysfs-root=/host/fake-sys` — with a `hostPath` mount of `/var/lib/fake-gpu-operator/sys`
   at `/host/fake-sys` in the `npe` container
 - a `nodeSelector` scoping `npe` to the fake-GPU nodes
 
-The `npe` binary accepts arbitrary values for both flags. Make sure the KAI scheduler's `numa`
-plugin keeps its default `reconstructAvailable=true` so it reconstructs per-zone availability
-from `npe`'s observed placements.
-
-## Dependency and interim option
+The `npe` binary accepts arbitrary values for both flags. `npe` writes the
+`kai.scheduler/numa-placement-observed` annotation on each pod, and the KAI scheduler's `numa`
+plugin (running with its default `reconstructAvailable=true`) reconstructs per-zone
+availability from those observed placements. Live `NodeResourceTopology` `available` is
+therefore **not** required on this path.
 
 The recommended integration relies on the KAI operator exposing the `npe` socket / sysfs-root /
 volume-mount settings so the operator-managed `npe` DaemonSet can be pointed at the FGO paths.
@@ -79,6 +84,6 @@ targets real nodes where pods execute).
 
 Shared/fractional GPUs (the reservation model, where a GPU's `allocatedBy` names a
 reservation pod in the reservation namespace rather than the workload) are also not covered:
-the synthesized entry would be named after the reservation pod, so `npe` would annotate that
-pod and the real workload pod would get no placement. Use whole-GPU (dedicated/DRA)
+the synthesized entry would be named after the reservation pod, so a consumer would attribute
+placement to that pod and the real workload pod would get none. Use whole-GPU (dedicated/DRA)
 allocations, where `allocatedBy` is the workload pod.


### PR DESCRIPTION
## What

Reframes the fake-podresources doc so it addresses **any** kubelet-podresources-API consumer, not only KAI-Scheduler's `npe`.

- Renames `docs/npe-podresources.md` → `docs/podresources.md`.
- Retitles to "Fake kubelet podresources + sysfs for NUMA placement".
- Adds a generic "Point a consumer at the FGO paths" section (socket + sysfs-root).
- Demotes the KAI-specific flags/annotation/`reconstructAvailable` details into an "Example: KAI numa-placement-exporter (`npe`)" section.
- Updates the one CHANGELOG reference to the new path.

## Why

fake-gpu-operator is expected to serve many clients. The podresources faking is a generic capability (a fake kubelet podresources gRPC socket + sysfs `cpulist` tree); tying the whole doc to KAI `npe` under-sells it and misleads other consumers.

No code or behavior change — docs only.