### PR TITLE
fix: build preloader for target architecture in multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,10 @@ COPY ./pkg/compute-domain/ ./pkg/compute-domain/
 COPY ./internal/kwok-compute-domain-dra-plugin/ ./internal/kwok-compute-domain-dra-plugin/
 RUN --mount=type=cache,target=/root/.cache/go-build make build OS=$TARGETOS ARCH=$TARGETARCH COMPONENTS=kwok-compute-domain-dra-plugin
 
-FROM common-builder AS preloader-builder 
-COPY ./cmd/preloader/ ./cmd/preloader/
-RUN make build-preloader
+FROM --platform=$TARGETPLATFORM golang:1.24.0 AS preloader-builder
+WORKDIR /build
+COPY ./cmd/preloader/main.c main.c
+RUN gcc -fPIC -shared -o /preloader.so main.c
 
 FROM jupyter/minimal-notebook AS jupyter-notebook
 COPY --from=nvidia-smi-builder /go/src/github.com/run-ai/fake-gpu-operator/bin/nvidia-smi /bin/
@@ -81,8 +82,8 @@ COPY --from=nvidia-smi-builder /go/src/github.com/run-ai/fake-gpu-operator/bin/n
 FROM ubuntu AS device-plugin
 COPY --from=device-plugin-builder /go/src/github.com/run-ai/fake-gpu-operator/bin/device-plugin /bin/
 COPY --from=nvidia-smi-builder /go/src/github.com/run-ai/fake-gpu-operator/bin/nvidia-smi /bin/
-COPY --from=preloader-builder /go/src/github.com/run-ai/fake-gpu-operator/bin/preloader /shared/memory/preloader.so
-COPY --from=preloader-builder /go/src/github.com/run-ai/fake-gpu-operator/bin/preloader /shared/pid/preloader.so
+COPY --from=preloader-builder /preloader.so /shared/memory/preloader.so
+COPY --from=preloader-builder /preloader.so /shared/pid/preloader.so
 ENTRYPOINT ["/bin/device-plugin"]
 
 FROM ubuntu AS status-updater


### PR DESCRIPTION
### Problem

When building images with `docker buildx --platform linux/amd64,linux/arm64`, the preloader-builder stage inherits `--platform=$BUILDPLATFORM` from `common-builder`. The `gcc` inside this stage produces a shared library for the build platform's architecture — not the target architecture.

### Solution

Switch the preloader-builder to `--platform=$TARGETPLATFORM golang:1.24.0` so that `gcc` output matches the intended target platform. During a multi-platform build, Docker runs one preloader-builder per target platform, each producing the correct `.so`.

### Changes

`Dockerfile` — 6 insertions, 5 deletions
- Replace `FROM common-builder` (implicit `BUILDPLATFORM`) with `FROM --platform=$TARGETPLATFORM golang:1.24.0`
- Use `gcc` directly instead of `make build-preloader` since the Makefile is no longer needed in the Docker stage
- Update COPY paths to match new output location `/preloader.so`

### Verification

```bash
# Single platform
docker buildx build --platform linux/arm64 --target device-plugin -t test .

# Multi-platform
make image DOCKER_BUILDX_PLATFORMS=linux/amd64,linux/arm64
```

### AI Assistance

This pull request was created with the assistance of an AI coding agent (OpenCode / Claude). All changes were reviewed by the author before submission.
