### PR TITLE
fix: propagate device plugin creation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `kwok-compute-domain-dra-plugin` image is now built and pushed by the
   release pipeline. It was missing from the CI release matrix, so enabling
   `kwokComputeDomainDraPlugin.enabled` caused an `ImagePullBackOff`. (RUN-41041)
+- Propagated errors from device UUID generation and device plugin creation
+  instead of ignoring them. `NewDevicePlugins` now returns an error, and the
+  device-plugin entrypoint handles it.
 
 ## [0.2.0] - 2026-07-01
 

--- a/cmd/device-plugin/main.go
+++ b/cmd/device-plugin/main.go
@@ -73,12 +73,8 @@ func initPreloaders() {
 
 func publish(srcFile string, destFile string) {
 	srcFileInfo, err := os.Stat(srcFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			log.Printf("%s not found in %s\n", path.Base(srcFile), srcFile)
-		} else {
-			log.Printf("Failed to stat %s: %s\n", srcFile, err)
-		}
+	if os.IsNotExist(err) {
+		log.Printf("%s not found in %s\n", path.Base(srcFile), srcFile)
 		return
 	}
 

--- a/cmd/device-plugin/main.go
+++ b/cmd/device-plugin/main.go
@@ -42,7 +42,11 @@ func main() {
 	initNvidiaSmi()
 	initPreloaders()
 
-	devicePlugins := deviceplugin.NewDevicePlugins(topology, kubeClient)
+	devicePlugins, err := deviceplugin.NewDevicePlugins(topology, kubeClient)
+	if err != nil {
+		log.Printf("Failed to create device plugins: %s\n", err)
+		os.Exit(1)
+	}
 	for _, devicePlugin := range devicePlugins {
 		log.Printf("Starting device plugin for %s\n", devicePlugin.Name())
 		if err = devicePlugin.Serve(); err != nil {
@@ -69,8 +73,12 @@ func initPreloaders() {
 
 func publish(srcFile string, destFile string) {
 	srcFileInfo, err := os.Stat(srcFile)
-	if os.IsNotExist(err) {
-		log.Printf("%s not found in %s\n", path.Base(srcFile), srcFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("%s not found in %s\n", path.Base(srcFile), srcFile)
+		} else {
+			log.Printf("Failed to stat %s: %s\n", srcFile, err)
+		}
 		return
 	}
 

--- a/internal/deviceplugin/device_plugin.go
+++ b/internal/deviceplugin/device_plugin.go
@@ -1,6 +1,7 @@
 package deviceplugin
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -20,7 +21,7 @@ type Interface interface {
 	Name() string
 }
 
-func NewDevicePlugins(topology *topology.NodeTopology, kubeClient kubernetes.Interface) []Interface {
+func NewDevicePlugins(topology *topology.NodeTopology, kubeClient kubernetes.Interface) ([]Interface, error) {
 	if topology == nil {
 		panic("topology is nil")
 	}
@@ -35,26 +36,35 @@ func NewDevicePlugins(topology *topology.NodeTopology, kubeClient kubernetes.Int
 			kubeClient:   kubeClient,
 			gpuCount:     getGpuCount(topology),
 			otherDevices: otherDevices,
-		}}
+		}}, nil
+	}
+
+	gpuDevs, err := createDevices(getGpuCount(topology))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GPU devices: %w", err)
 	}
 
 	devicePlugins := []Interface{
 		&RealNodeDevicePlugin{
-			devs:         createDevices(getGpuCount(topology)),
+			devs:         gpuDevs,
 			socket:       serverSock,
 			resourceName: nvidiaGPUResourceName,
 		},
 	}
 
 	for _, genericDevice := range topology.OtherDevices {
+		otherDevs, err := createDevices(genericDevice.Count)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create devices for %s: %w", genericDevice.Name, err)
+		}
 		devicePlugins = append(devicePlugins, &RealNodeDevicePlugin{
-			devs:         createDevices(genericDevice.Count),
+			devs:         otherDevs,
 			socket:       path.Join(pluginapi.DevicePluginPath, normalizeDeviceName(genericDevice.Name)+".sock"),
 			resourceName: genericDevice.Name,
 		})
 	}
 
-	return devicePlugins
+	return devicePlugins, nil
 }
 
 func normalizeDeviceName(deviceName string) string {

--- a/internal/deviceplugin/device_plugin_test.go
+++ b/internal/deviceplugin/device_plugin_test.go
@@ -1,8 +1,10 @@
 package deviceplugin
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/viper"
@@ -66,6 +68,23 @@ var _ = Describe("NewDevicePlugins", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(devicePlugins).To(HaveLen(3))
 			Expect(devicePlugins[0]).To(BeAssignableToTypeOf(&RealNodeDevicePlugin{}))
+		})
+	})
+
+	Context("when device UUID generation fails", func() {
+		It("should propagate the error from NewDevicePlugins", func() {
+			original := uuidNewRandom
+			uuidNewRandom = func() (uuid.UUID, error) { return uuid.UUID{}, errors.New("rng failed") }
+			defer func() { uuidNewRandom = original }()
+
+			topology := &topology.NodeTopology{
+				Gpus: []topology.GpuDetails{{ID: "gpu-0"}},
+			}
+			kubeClient := &fake.Clientset{}
+			devicePlugins, err := NewDevicePlugins(topology, kubeClient)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create GPU devices"))
+			Expect(devicePlugins).To(BeNil())
 		})
 	})
 

--- a/internal/deviceplugin/device_plugin_test.go
+++ b/internal/deviceplugin/device_plugin_test.go
@@ -21,7 +21,7 @@ func TestDevicePlugin(t *testing.T) {
 var _ = Describe("NewDevicePlugins", func() {
 	Context("When the topology is nil", func() {
 		It("should panic", func() {
-			Expect(func() { NewDevicePlugins(nil, nil) }).To(Panic())
+			Expect(func() { _, _ = NewDevicePlugins(nil, nil) }).To(Panic())
 		})
 	})
 
@@ -37,7 +37,8 @@ var _ = Describe("NewDevicePlugins", func() {
 		It("should return a fake node device plugin", func() {
 			topology := &topology.NodeTopology{}
 			kubeClient := &fake.Clientset{}
-			devicePlugins := NewDevicePlugins(topology, kubeClient)
+			devicePlugins, err := NewDevicePlugins(topology, kubeClient)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(devicePlugins).To(HaveLen(1))
 			Expect(devicePlugins[0]).To(BeAssignableToTypeOf(&FakeNodeDevicePlugin{}))
 		})
@@ -47,7 +48,8 @@ var _ = Describe("NewDevicePlugins", func() {
 		It("should return a real node device plugin", func() {
 			topology := &topology.NodeTopology{}
 			kubeClient := &fake.Clientset{}
-			devicePlugins := NewDevicePlugins(topology, kubeClient)
+			devicePlugins, err := NewDevicePlugins(topology, kubeClient)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(devicePlugins).To(HaveLen(1))
 			Expect(devicePlugins[0]).To(BeAssignableToTypeOf(&RealNodeDevicePlugin{}))
 		})
@@ -60,7 +62,8 @@ var _ = Describe("NewDevicePlugins", func() {
 				},
 			}
 			kubeClient := &fake.Clientset{}
-			devicePlugins := NewDevicePlugins(topology, kubeClient)
+			devicePlugins, err := NewDevicePlugins(topology, kubeClient)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(devicePlugins).To(HaveLen(3))
 			Expect(devicePlugins[0]).To(BeAssignableToTypeOf(&RealNodeDevicePlugin{}))
 		})

--- a/internal/deviceplugin/real_node.go
+++ b/internal/deviceplugin/real_node.go
@@ -65,10 +65,13 @@ func dial(unixSocketPath string, timeout time.Duration) (*grpc.ClientConn, error
 	return c, nil
 }
 
+// uuidNewRandom is overridable for tests.
+var uuidNewRandom = uuid.NewRandom
+
 func createDevices(devCount int) ([]*pluginapi.Device, error) {
 	var devs []*pluginapi.Device
 	for i := 0; i < devCount; i++ {
-		u, err := uuid.NewRandom()
+		u, err := uuidNewRandom()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate device UUID: %w", err)
 		}
@@ -151,8 +154,9 @@ func (m *RealNodeDevicePlugin) Register(kubeletEndpoint string) error {
 }
 
 func (m *RealNodeDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
-	if err := s.Send(&pluginapi.ListAndWatchResponse{Devices: m.devs}); err != nil {
-		return fmt.Errorf("failed to send devices to Kubelet: %w", err)
+	err := s.Send(&pluginapi.ListAndWatchResponse{Devices: m.devs})
+	if err != nil {
+		fmt.Printf("Failed to send devices to Kubelet: %v\n", err)
 	}
 
 	for {

--- a/internal/deviceplugin/real_node.go
+++ b/internal/deviceplugin/real_node.go
@@ -65,16 +65,19 @@ func dial(unixSocketPath string, timeout time.Duration) (*grpc.ClientConn, error
 	return c, nil
 }
 
-func createDevices(devCount int) []*pluginapi.Device {
+func createDevices(devCount int) ([]*pluginapi.Device, error) {
 	var devs []*pluginapi.Device
 	for i := 0; i < devCount; i++ {
-		u, _ := uuid.NewRandom()
+		u, err := uuid.NewRandom()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate device UUID: %w", err)
+		}
 		devs = append(devs, &pluginapi.Device{
 			ID:     u.String(),
 			Health: pluginapi.Healthy,
 		})
 	}
-	return devs
+	return devs, nil
 }
 
 func (m *RealNodeDevicePlugin) Start() error {
@@ -148,9 +151,8 @@ func (m *RealNodeDevicePlugin) Register(kubeletEndpoint string) error {
 }
 
 func (m *RealNodeDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
-	err := s.Send(&pluginapi.ListAndWatchResponse{Devices: m.devs})
-	if err != nil {
-		fmt.Printf("Failed to send devices to Kubelet: %v\n", err)
+	if err := s.Send(&pluginapi.ListAndWatchResponse{Devices: m.devs}); err != nil {
+		return fmt.Errorf("failed to send devices to Kubelet: %w", err)
 	}
 
 	for {


### PR DESCRIPTION
## Description

Propagates errors from device UUID generation and device plugin creation instead of ignoring them. Previously, uuid.NewRandom() errors were discarded and createDevices() could not fail; now failures surface through NewDevicePlugins, and the device-plugin entrypoint exits cleanly when creation fails. Tests were updated for the new signature.

## Verification

- go build ./...
- go vet ./...
- golangci-lint run ./...
- go test $(go list ./... | grep -v '/test/e2e')

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (device_plugin_test.go updated for new error return)
- [ ] Updated documentation (not needed)
- [x] Updated CHANGELOG.md under ## [Unreleased]

## Breaking Changes

None for external users. Internal signature of NewDevicePlugins changed to return ([]Interface, error).

## Additional Notes

N/A