### PR TITLE
feat(dra-plugin): add configurable GPU device naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `kwok-dra-plugin` now supports a `GPU_DEVICE_NAMING` setting
+  (`kwokDraPlugin.gpuDeviceNaming` in the Helm chart) to opt into a
+  deterministic per-node sequential device naming scheme (`gpu-0`,
+  `gpu-1`, ...) matching the real NVIDIA driver, as an alternative to the
+  existing UUID-based naming (`uuid`, still the default).
+  `status-updater`'s device lookup tries deterministic-index matching
+  first, then falls back to UUID matching, so it works correctly
+  regardless of which mode produced the allocated device name.
+
 ### Changed
 
 ### Fixed

--- a/deploy/fake-gpu-operator/templates/kwok-dra-plugin/deployment.yaml
+++ b/deploy/fake-gpu-operator/templates/kwok-dra-plugin/deployment.yaml
@@ -30,6 +30,8 @@ spec:
               value: "{{ .Release.Namespace }}"
             - name: FAKE_GPU_OPERATOR_NAMESPACE
               value: "{{ .Release.Namespace }}"
+            - name: GPU_DEVICE_NAMING
+              value: "{{ (.Values.kwokDraPlugin).gpuDeviceNaming | default "uuid" }}"
       restartPolicy: Always
       serviceAccountName: kwok-dra-plugin
       imagePullSecrets:

--- a/deploy/fake-gpu-operator/values.yaml
+++ b/deploy/fake-gpu-operator/values.yaml
@@ -101,6 +101,7 @@ kwokGpuDevicePlugin:
 
 kwokDraPlugin:
   enabled: false
+  gpuDeviceNaming: uuid
   image:
     pullPolicy: Always
     repository: ghcr.io/run-ai/fake-gpu-operator/kwok-dra-plugin

--- a/internal/common/constants/constants.go
+++ b/internal/common/constants/constants.go
@@ -46,4 +46,8 @@ const (
 	EnvRunaiIntegrationPollingInterval = "RUNAI_INTEGRATION_POLLING_INTERVAL"
 	EnvNodeResourceTopologyEnabled     = "NODE_RESOURCE_TOPOLOGY_ENABLED"
 	EnvPodResourcesEnabled             = "POD_RESOURCES_ENABLED"
+	EnvGpuDeviceNaming                 = "GPU_DEVICE_NAMING"
+
+	GpuDeviceNamingDeterministic = "deterministic"
+	GpuDeviceNamingUuid          = "uuid"
 )

--- a/internal/kwok-dra-plugin/app.go
+++ b/internal/kwok-dra-plugin/app.go
@@ -19,6 +19,7 @@ import (
 type KWOKDraPluginAppConfiguration struct {
 	TopologyCmName      string `mapstructure:"TOPOLOGY_CM_NAME" validate:"required"`
 	TopologyCmNamespace string `mapstructure:"TOPOLOGY_CM_NAMESPACE" validate:"required"`
+	GpuDeviceNaming     string `mapstructure:"GPU_DEVICE_NAMING"`
 }
 
 type KWOKDraPluginApp struct {
@@ -80,8 +81,13 @@ func (app *KWOKDraPluginApp) Init(stopCh chan struct{}) {
 		log.Fatalf("Failed to create kubernetes client: %v", err)
 	}
 
+	// An empty/unset value is handled by devicesFromTopology itself,
+	// which treats anything other than an explicit "deterministic" as
+	// "uuid" -- upstream's original, unconditional naming.
+	gpuDeviceNaming := viper.GetString(constants.EnvGpuDeviceNaming)
+
 	// Setup ConfigMap reconciler
-	if err := cmcontroller.SetupWithManager(app.mgr, kubeClient, namespace, topologyCMName); err != nil {
+	if err := cmcontroller.SetupWithManager(app.mgr, kubeClient, namespace, topologyCMName, gpuDeviceNaming); err != nil {
 		log.Fatalf("Failed to setup ConfigMap controller: %v", err)
 	}
 }

--- a/internal/kwok-dra-plugin/controllers/configmap/reconciler.go
+++ b/internal/kwok-dra-plugin/controllers/configmap/reconciler.go
@@ -100,8 +100,8 @@ func isFakeGpuKWOKNodeConfigMap(cm *corev1.ConfigMap) bool {
 }
 
 // SetupWithManager creates and sets up the ConfigMap reconciler with the manager
-func SetupWithManager(mgr ctrl.Manager, kubeClient kubernetes.Interface, namespace, topologyCMName string) error {
-	handler := rshandler.NewResourceSliceHandler(kubeClient)
+func SetupWithManager(mgr ctrl.Manager, kubeClient kubernetes.Interface, namespace, topologyCMName, gpuDeviceNaming string) error {
+	handler := rshandler.NewResourceSliceHandler(kubeClient, gpuDeviceNaming)
 
 	reconciler := &ConfigMapReconciler{
 		Client:           mgr.GetClient(),

--- a/internal/kwok-dra-plugin/handlers/resourceslice/handler.go
+++ b/internal/kwok-dra-plugin/handlers/resourceslice/handler.go
@@ -30,15 +30,17 @@ type Interface interface {
 
 // ResourceSliceHandler handles ResourceSlice operations for KWOK nodes
 type ResourceSliceHandler struct {
-	kubeClient kubernetes.Interface
+	kubeClient      kubernetes.Interface
+	gpuDeviceNaming string
 }
 
 var _ Interface = &ResourceSliceHandler{}
 
 // NewResourceSliceHandler creates a new ResourceSliceHandler
-func NewResourceSliceHandler(kubeClient kubernetes.Interface) *ResourceSliceHandler {
+func NewResourceSliceHandler(kubeClient kubernetes.Interface, gpuDeviceNaming string) *ResourceSliceHandler {
 	return &ResourceSliceHandler{
-		kubeClient: kubeClient,
+		kubeClient:      kubeClient,
+		gpuDeviceNaming: gpuDeviceNaming,
 	}
 }
 
@@ -127,14 +129,24 @@ func (h *ResourceSliceHandler) devicesFromTopology(nodeTopology *topology.NodeTo
 	// Convert GpuMemory from MB to bytes for resource.Quantity
 	memoryBytes := int64(nodeTopology.GpuMemory) * 1024 * 1024
 
-	for _, gpu := range nodeTopology.Gpus {
+	for i, gpu := range nodeTopology.Gpus {
 		if gpu.ID == "" {
 			log.Printf("Warning: GPU entry missing ID in topology, skipping")
 			continue
 		}
 
-		// Use ID (UUID) as device name, convert to lowercase for RFC 1123 compliance
-		deviceName := strings.ToLower(gpu.ID)
+		var deviceName string
+		if h.gpuDeviceNaming == constants.GpuDeviceNamingDeterministic {
+			// Use deterministic per-node sequential index (gpu-0, gpu-1, ...) matching real NVIDIA driver
+			deviceName = fmt.Sprintf("gpu-%d", i)
+		} else {
+			// UUID is upstream's original, unconditional naming -- the
+			// fallback for anything other than an explicit "deterministic"
+			// opt-in, so a zero-value handler (e.g. one constructed
+			// without going through NewResourceSliceHandler at all)
+			// still matches upstream's original behavior.
+			deviceName = strings.ToLower(gpu.ID)
+		}
 
 		// gpu.nvidia.com/* keys are required: upstream DeviceClass CEL reads
 		// device.attributes['gpu.nvidia.com'].type. Unqualified uuid/model kept for back-compat.

--- a/internal/kwok-dra-plugin/handlers/resourceslice/handler_test.go
+++ b/internal/kwok-dra-plugin/handlers/resourceslice/handler_test.go
@@ -50,7 +50,7 @@ var _ = Describe("ResourceSliceHandler", func() {
 
 			fakeClient := fake.NewSimpleClientset()
 
-			handler := NewResourceSliceHandler(fakeClient)
+			handler := NewResourceSliceHandler(fakeClient, "")
 			err = handler.HandleAddOrUpdate(configMap)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -90,7 +90,7 @@ var _ = Describe("ResourceSliceHandler", func() {
 
 			fakeClient := fake.NewSimpleClientset()
 
-			handler := NewResourceSliceHandler(fakeClient)
+			handler := NewResourceSliceHandler(fakeClient, "")
 
 			// Create initial ResourceSlice
 			err = handler.HandleAddOrUpdate(configMap)
@@ -146,7 +146,7 @@ var _ = Describe("ResourceSliceHandler", func() {
 
 			fakeClient := fake.NewSimpleClientset()
 
-			handler := NewResourceSliceHandler(fakeClient)
+			handler := NewResourceSliceHandler(fakeClient, "")
 
 			// Create ResourceSlice
 			err = handler.HandleAddOrUpdate(configMap)
@@ -196,6 +196,38 @@ var _ = Describe("ResourceSliceHandler", func() {
 
 			// Check second device
 			Expect(devices[1].Name).To(Equal("gpu-0002-0002-0002-0002"))
+			Expect(*devices[1].Attributes["uuid"].StringValue).To(Equal("GPU-0002-0002-0002-0002"))
+			Expect(*devices[1].Attributes["gpu.nvidia.com/type"].StringValue).To(Equal("gpu"))
+			Expect(*devices[1].Attributes["gpu.nvidia.com/uuid"].StringValue).To(Equal("GPU-0002-0002-0002-0002"))
+		})
+
+		It("should convert topology GPUs to DRA devices using deterministic index naming when configured", func() {
+			handler := &ResourceSliceHandler{gpuDeviceNaming: constants.GpuDeviceNamingDeterministic}
+
+			nodeTopology := &topology.NodeTopology{
+				GpuProduct: "NVIDIA-A100-SXM4-40GB",
+				GpuMemory:  40960,
+				Gpus: []topology.GpuDetails{
+					{ID: "GPU-0001-0001-0001-0001"},
+					{ID: "GPU-0002-0002-0002-0002"},
+				},
+			}
+
+			devices := handler.devicesFromTopology(nodeTopology)
+
+			Expect(devices).To(HaveLen(2))
+
+			// Check first device
+			Expect(devices[0].Name).To(Equal("gpu-0"))
+			Expect(*devices[0].Attributes["uuid"].StringValue).To(Equal("GPU-0001-0001-0001-0001"))
+			Expect(*devices[0].Attributes["model"].StringValue).To(Equal("NVIDIA-A100-SXM4-40GB"))
+
+			Expect(*devices[0].Attributes["gpu.nvidia.com/type"].StringValue).To(Equal("gpu"))
+			Expect(*devices[0].Attributes["gpu.nvidia.com/uuid"].StringValue).To(Equal("GPU-0001-0001-0001-0001"))
+			Expect(*devices[0].Attributes["gpu.nvidia.com/productName"].StringValue).To(Equal("NVIDIA-A100-SXM4-40GB"))
+
+			// Check second device
+			Expect(devices[1].Name).To(Equal("gpu-1"))
 			Expect(*devices[1].Attributes["uuid"].StringValue).To(Equal("GPU-0002-0002-0002-0002"))
 			Expect(*devices[1].Attributes["gpu.nvidia.com/type"].StringValue).To(Equal("gpu"))
 			Expect(*devices[1].Attributes["gpu.nvidia.com/uuid"].StringValue).To(Equal("GPU-0002-0002-0002-0002"))

--- a/internal/status-updater/handlers/pod/dra_gpu_pod_handler.go
+++ b/internal/status-updater/handlers/pod/dra_gpu_pod_handler.go
@@ -218,12 +218,29 @@ func getDevicesFromClaim(claim *resourceapi.ResourceClaim) []string {
 // findGpuIndexByID finds the index of a GPU in the topology by its ID.
 // The comparison is case-insensitive because the DRA plugin uses lowercase device names
 // while the topology may have uppercase GPU IDs.
+//
+// Tries deterministic index naming first, then falls back to UUID matching --
+// kwok-dra-plugin's naming mode is a per-deployment config choice, so this
+// stays correct regardless of which mode produced the allocated device name.
 func findGpuIndexByID(nodeTopology *topology.NodeTopology, gpuID string) int {
 	for idx, gpu := range nodeTopology.Gpus {
+		if gpu.ID == "" {
+			continue
+		}
+		if strings.EqualFold(fmt.Sprintf("gpu-%d", idx), gpuID) {
+			return idx
+		}
+	}
+
+	for idx, gpu := range nodeTopology.Gpus {
+		if gpu.ID == "" {
+			continue
+		}
 		if strings.EqualFold(gpu.ID, gpuID) {
 			return idx
 		}
 	}
+
 	return -1
 }
 

--- a/internal/status-updater/handlers/pod/dra_gpu_pod_handler_test.go
+++ b/internal/status-updater/handlers/pod/dra_gpu_pod_handler_test.go
@@ -407,6 +407,11 @@ var _ = Describe("DRA GPU Pod Handler", func() {
 			Expect(idx).To(Equal(1))
 		})
 
+		It("should find GPU by deterministic index naming (gpu-<idx>)", func() {
+			idx := findGpuIndexByID(nodeTopology, "gpu-1")
+			Expect(idx).To(Equal(1))
+		})
+
 		It("should return -1 for non-existent GPU", func() {
 			idx := findGpuIndexByID(nodeTopology, "gpu-9999-9999-9999-9999")
 			Expect(idx).To(Equal(-1))


### PR DESCRIPTION
## Description

kwok-dra-plugin names DRA devices after the topology's GPU UUID (e.g.
`gpu-0001-0001-0001-0001`). The real NVIDIA DRA driver names devices by
GPU minor instead — `gpu-<minor>`, see `GpuInfo.CanonicalName()` in
[deviceinfo.go](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/v0.4.1/cmd/gpu-kubelet-plugin/deviceinfo.go#L106-L108).
That's the version [GPU Operator v26.3.3 currently pins](https://github.com/NVIDIA/gpu-operator/blob/v26.3.3/deployments/gpu-operator/values.yaml)
(`draDriver.version: v0.4.1`), so it's not a stale reference. Anything
built against the real naming convention doesn't line up with this
simulator's output today.

Worth flagging: GPU Operator still ships the DRA stack as experimental
(`gpuCluster.deployCR` defaults to disabled), so this isn't the common
path yet — but it's the real one when DRA is on.

Adds a `GPU_DEVICE_NAMING` setting (`kwokDraPlugin.gpuDeviceNaming`) with
two modes:

- `uuid` (default, unchanged): current UUID-based naming.
- `deterministic`: sequential per-node index naming (`gpu-0`, `gpu-1`,
  ...), matching the real driver.

`status-updater`'s device lookup tries index matching first, then falls
back to UUID, so it works either way regardless of which mode produced
the device name.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./internal/kwok-dra-plugin/... ./internal/status-updater/...`
- Ran both modes end-to-end on a live KWOK cluster — ResourceSlice device
  names, status-updater's allocation tracking, and downstream SLURM GRES
  reporting all check out in both.

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests
- [x] Updated documentation (Helm chart values)
- [x] Updated CHANGELOG.md under `## [Unreleased]`

## Breaking Changes

None — `uuid` stays the default. `deterministic` is opt-in.