### PR TITLE
fix(ci): unblock release-docker push to new GHCR packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,8 +242,6 @@ jobs:
       contents: read
       packages: write
     strategy:
-      # Don't let one component's push failure cancel the others (or silently
-      # block release-helm via `needs`). Surface every component result.
       fail-fast: false
       matrix:
         component: [device-plugin, dra-plugin-gpu, status-updater, kwok-gpu-device-plugin, kwok-dra-plugin, kwok-compute-domain-dra-plugin, status-exporter, topology-server, mig-faker, jupyter-notebook, compute-domain-controller, compute-domain-dra-plugin]
@@ -263,10 +261,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          # Disable provenance/SBOM attestations. Their extra attestation
-          # manifests trip a `denied: permission_denied: read_package` error on
-          # the first push to a not-yet-created GHCR package (the cause of the
-          # kwok-compute-domain-dra-plugin release failures since #232).
           provenance: false
           tags: ${{ env.DOCKER_REGISTRY }}/${{ matrix.component }}:${{ needs.set-release-vars.outputs.release_version }}
           target: ${{ matrix.component }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,9 @@ jobs:
       contents: read
       packages: write
     strategy:
+      # Don't let one component's push failure cancel the others (or silently
+      # block release-helm via `needs`). Surface every component result.
+      fail-fast: false
       matrix:
         component: [device-plugin, dra-plugin-gpu, status-updater, kwok-gpu-device-plugin, kwok-dra-plugin, kwok-compute-domain-dra-plugin, status-exporter, topology-server, mig-faker, jupyter-notebook, compute-domain-controller, compute-domain-dra-plugin]
     steps:
@@ -260,6 +263,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
+          # Disable provenance/SBOM attestations. Their extra attestation
+          # manifests trip a `denied: permission_denied: read_package` error on
+          # the first push to a not-yet-created GHCR package (the cause of the
+          # kwok-compute-domain-dra-plugin release failures since #232).
+          provenance: false
           tags: ${{ env.DOCKER_REGISTRY }}/${{ matrix.component }}:${{ needs.set-release-vars.outputs.release_version }}
           target: ${{ matrix.component }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The `release-docker` job has failed on **every** `main` build since 2026-07-05, when [#232](https://github.com/run-ai/fake-gpu-operator/pull/232) added `kwok-compute-domain-dra-plugin` to the release matrix. In each run it is the only failing job — the sibling image builds succeed or get fail-fast-cancelled.

Root cause: the `kwok-compute-domain-dra-plugin` GHCR package has never existed (`GET /orgs/run-ai/packages/container/fake-gpu-operator/kwok-compute-domain-dra-plugin` → 404), and the push fails with:

```
denied: permission_denied: read_package
```

The image itself builds fine for both `linux/amd64` and `linux/arm64`; only the push fails. This is the known `docker/build-push-action@v6` behavior where the default provenance/SBOM attestation manifests require reading the target package, which trips a permission error on the **first** push to a not-yet-created GHCR package.

## Changes

- `provenance: false` on the `Build and push` step, so the first push can create the package without the attestation read.
- `fail-fast: false` on the `release-docker` matrix, so one component's push failure no longer cancels the other image pushes or silently blocks `release-helm` (which has `needs: [release-docker]` — no `0.0.0-<sha>` chart has published from `main` since July 5).

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed) — n/a, CI-only change
- [x] Updated documentation (if needed) — n/a
- [ ] Updated `CHANGELOG.md` — n/a, internal CI change (`skip-changelog`)

## Breaking Changes

None.

## Additional Notes

Validated the workflow YAML parses cleanly. This is the low-cost attempt at fixing the release pipeline without any manual registry work: if the org allows Actions to create packages (it did for the existing sibling images), the next `main` run should create and push `kwok-compute-domain-dra-plugin` successfully.

If the push still returns `permission_denied` after this, the cause is genuinely org package-creation policy, and the fallback is a one-time manual seed of the package by someone with `write:packages` on `run-ai` (push once, set the package public, grant the `fake-gpu-operator` repo Write access — matching the existing images).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-959ce56b-4e86-478d-9353-ca01c5abb987?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-959ce56b-4e86-478d-9353-ca01c5abb987&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

