### PR TITLE
ci: restore provenance attestations on release images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          provenance: false
           tags: ${{ env.DOCKER_REGISTRY }}/${{ matrix.component }}:${{ needs.set-release-vars.outputs.release_version }}
           target: ${{ matrix.component }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up to [#244](https://github.com/run-ai/fake-gpu-operator/pull/244). That PR added `provenance: false` on a hypothesis that the default provenance/SBOM attestation manifests were causing the `release-docker (kwok-compute-domain-dra-plugin)` push failure. The post-merge `main` run disproved that: the job still fails with `denied: permission_denied: read_package`, and the 11 pre-existing packages push fine — so the real blocker is **package creation/access permission** for the not-yet-created `kwok-compute-domain-dra-plugin` package, not attestations.

Since disabling provenance wasn't the fix and provenance/SBOM attestations carry supply-chain (SLSA) value, this restores the default behavior by dropping the `provenance: false` line.

`fail-fast: false` (also from #244) is intentionally kept — it's clearly helping (11/12 components now publish instead of the whole matrix cancelling on the first failure).

## Changes

- Remove `provenance: false` from the `release-docker` `Build and push` step, restoring default provenance/SBOM attestations for all release images.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed) — n/a, CI-only change
- [x] Updated documentation (if needed) — n/a
- [ ] Updated `CHANGELOG.md` — n/a, internal CI change (`skip-changelog`)

## Breaking Changes

None.

## Additional Notes

This does not fix the `kwok-compute-domain-dra-plugin` release failure — that requires a one-time manual seed of the GHCR package by someone with `write:packages` on `run-ai` (push once, set the package public, grant the `fake-gpu-operator` repo Write access), after which CI pushes will succeed and `release-helm` will unblock.

Workflow YAML validated as well-formed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-959ce56b-4e86-478d-9353-ca01c5abb987?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-959ce56b-4e86-478d-9353-ca01c5abb987&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

